### PR TITLE
fix: Make the spelling of .gitignore consistent

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -137,7 +137,7 @@ export function addCommmands(plugin: ObsidianGit) {
 
     plugin.addCommand({
         id: "add-to-gitignore",
-        name: "Add file to gitignore",
+        name: "Add file to .gitignore",
         checkCallback: (checking) => {
             const file = app.workspace.getActiveFile();
             if (checking) {


### PR DESCRIPTION
Everywhere else in the commands and the docs do you use `.gitignore` except for this one command. Just making it consistent.