### PR TITLE
fix: improve the "is file openable in obsidian" check

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -321,10 +321,19 @@ declare module "obsidian" {
         saveLocalStorage(key: string, value: string | undefined): void;
         openWithDefaultApp(path: string): void;
         getTheme(): "obsidian" | "moonstone";
+        viewRegistry: ViewRegistry;
     }
     interface View {
         titleEl: HTMLElement;
         inlineTitleEl: HTMLElement;
+    }
+    interface ViewRegistry {
+        /**
+         * PRIVATE API
+         *
+         * Returns the view type for the given extension if available.
+         */
+        getTypeByExtension(extension: string): string;
     }
     interface Workspace {
         /**

--- a/src/ui/history/components/logFileComponent.svelte
+++ b/src/ui/history/components/logFileComponent.svelte
@@ -3,6 +3,7 @@
     import type { DiffFile } from "src/types";
     import {
         fileIsBinary,
+        fileOpenableInObsidian,
         getDisplayPath,
         getNewLeaf,
         mayTriggerFileMenu,
@@ -87,7 +88,7 @@
         </div>
         <div class="git-tools">
             <div class="buttons">
-                {#if view.app.vault.getAbstractFileByPath(diff.vaultPath) instanceof TFile}
+                {#if fileOpenableInObsidian(diff.vaultPath, view.app)}
                     <div
                         data-icon="go-to-file"
                         aria-label="Open File"

--- a/src/ui/sourceControl/components/fileComponent.svelte
+++ b/src/ui/sourceControl/components/fileComponent.svelte
@@ -6,6 +6,7 @@
     import { DiscardModal } from "src/ui/modals/discardModal";
     import {
         fileIsBinary,
+        fileOpenableInObsidian,
         getDisplayPath,
         getNewLeaf,
         mayTriggerFileMenu,
@@ -141,7 +142,7 @@
         </div>
         <div class="git-tools">
             <div class="buttons">
-                {#if view.app.vault.getAbstractFileByPath(change.vaultPath) instanceof TFile}
+                {#if fileOpenableInObsidian(change.vaultPath, view.app)}
                     <div
                         data-icon="go-to-file"
                         aria-label="Open File"

--- a/src/ui/sourceControl/components/stagedFileComponent.svelte
+++ b/src/ui/sourceControl/components/stagedFileComponent.svelte
@@ -5,6 +5,7 @@
     import type { FileStatusResult } from "src/types";
     import {
         fileIsBinary,
+        fileOpenableInObsidian,
         getDisplayPath,
         getNewLeaf,
         mayTriggerFileMenu,
@@ -108,7 +109,7 @@
         </div>
         <div class="git-tools">
             <div class="buttons">
-                {#if view.app.vault.getAbstractFileByPath(change.vaultPath) instanceof TFile}
+                {#if fileOpenableInObsidian(change.vaultPath, view.app)}
                     <div
                         data-icon="go-to-file"
                         aria-label="Open File"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,7 +196,7 @@ export function fileOpenableInObsidian(
         return false;
     }
     try {
-        // @ts-ignore (Internal Obsidian API function)
+        // @ts-expect-error (Internal Obsidian API function)
         return !!app.viewRegistry.getTypeByExtension(file.extension);
     } catch {
         // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import * as cssColorConverter from "css-color-converter";
 import deepEqual from "deep-equal";
 import type { App, RGB, WorkspaceLeaf } from "obsidian";
-import { Keymap, Menu, moment } from "obsidian";
+import { Keymap, Menu, moment, TFile } from "obsidian";
 import { BINARY_EXTENSIONS } from "./constants";
 
 export const worthWalking = (filepath: string, root?: string) => {
@@ -185,4 +185,21 @@ export function formatRemoteUrl(url: string): string {
         }
     }
     return url;
+}
+
+export function fileOpenableInObsidian(
+    relativeVaultPath: string,
+    app: App
+): boolean {
+    const file = app.vault.getAbstractFileByPath(relativeVaultPath);
+    if (!(file instanceof TFile)) {
+        return false;
+    }
+    try {
+        // @ts-ignore (Internal Obsidian API function)
+        return !!app.viewRegistry.getTypeByExtension(file.extension);
+    } catch {
+        // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.
+        return true;
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,7 +197,9 @@ export function fileOpenableInObsidian(
     }
     try {
         // Internal Obsidian API function
-        // @ts-expect-error, eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        // If a view type is registired for the file extension, it can be opened in Obsidian.
+        // Just checking if Obsidian tracks the file is not enough,
+        // because it can also track files, it can only open externally.
         return !!app.viewRegistry.getTypeByExtension(file.extension);
     } catch {
         // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,7 +197,9 @@ export function fileOpenableInObsidian(
     }
     try {
         // Internal Obsidian API function
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const viewRegistry = (app as any).viewRegistry;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return !!viewRegistry.getTypeByExtension(file.extension);
     } catch {
         // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,8 +197,8 @@ export function fileOpenableInObsidian(
     }
     try {
         // Internal Obsidian API function
-        // @ts-expect-error, eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        return !!app.viewRegistry.getTypeByExtension(file.extension);
+        const viewRegistry = (app as any).viewRegistry;
+        return !!viewRegistry.getTypeByExtension(file.extension);
     } catch {
         // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.
         return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,10 +197,8 @@ export function fileOpenableInObsidian(
     }
     try {
         // Internal Obsidian API function
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const viewRegistry = (app as any).viewRegistry;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        return !!viewRegistry.getTypeByExtension(file.extension);
+        // @ts-expect-error, eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+        return !!app.viewRegistry.getTypeByExtension(file.extension);
     } catch {
         // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.
         return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -196,7 +196,8 @@ export function fileOpenableInObsidian(
         return false;
     }
     try {
-        // @ts-expect-error (Internal Obsidian API function)
+        // Internal Obsidian API function
+        // @ts-expect-error, eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
         return !!app.viewRegistry.getTypeByExtension(file.extension);
     } catch {
         // If the function doesn't exist anymore, it will throw an error. In that case, just skip the check.


### PR DESCRIPTION
Closes #883 

Gracefully handles the case where the internal API function isn't available anymore.