### PR TITLE
fix: line authoring crashes when dom Element cannot be removed.

### DIFF
--- a/src/lineAuthor/view/gutter/gutter.ts
+++ b/src/lineAuthor/view/gutter/gutter.ts
@@ -55,7 +55,13 @@ export class TextGutter extends GutterMarker {
     }
 
     destroy(dom: HTMLElement): void {
-        if (!document.body.contains(dom)) dom.remove();
+        if (!dom) {
+            return; // sometimes, it doesn't exist anymore.
+        }
+
+        if (!document.body.contains(dom)) {
+            dom.remove();
+        }
     }
 }
 
@@ -115,10 +121,14 @@ export class LineAuthoringGutter extends GutterMarker {
     }
 
     public destroy(dom: HTMLElement): void {
+        if (!dom) {
+            return; // sometimes, it doesn't exist anymore.
+        }
+
         // this is called frequently, when the gutter moves outside of the view.
         if (!document.body.contains(dom)) {
-            dom.remove();
             attachedGutterElements.delete(dom);
+            dom.remove();
         }
     }
 
@@ -198,19 +208,19 @@ export class LineAuthoringGutter extends GutterMarker {
             this.settings.authorDisplay === "hide"
                 ? ""
                 : `${this.renderAuthorName(
-                      commit,
-                      this.settings.authorDisplay
-                  )}`;
+                    commit,
+                    this.settings.authorDisplay
+                )}`;
 
         const optionalAuthoringDate =
             this.settings.dateTimeFormatOptions === "hide"
                 ? ""
                 : `${this.renderAuthoringDate(
-                      commit,
-                      this.settings.dateTimeFormatOptions,
-                      this.settings.dateTimeFormatCustomString,
-                      this.settings.dateTimeTimezone
-                  )}`;
+                    commit,
+                    this.settings.dateTimeFormatOptions,
+                    this.settings.dateTimeFormatCustomString,
+                    this.settings.dateTimeTimezone
+                )}`;
 
         const parts = [
             optionalShortHash,

--- a/src/lineAuthor/view/gutter/gutter.ts
+++ b/src/lineAuthor/view/gutter/gutter.ts
@@ -208,19 +208,19 @@ export class LineAuthoringGutter extends GutterMarker {
             this.settings.authorDisplay === "hide"
                 ? ""
                 : `${this.renderAuthorName(
-                    commit,
-                    this.settings.authorDisplay
-                )}`;
+                      commit,
+                      this.settings.authorDisplay
+                  )}`;
 
         const optionalAuthoringDate =
             this.settings.dateTimeFormatOptions === "hide"
                 ? ""
                 : `${this.renderAuthoringDate(
-                    commit,
-                    this.settings.dateTimeFormatOptions,
-                    this.settings.dateTimeFormatCustomString,
-                    this.settings.dateTimeTimezone
-                )}`;
+                      commit,
+                      this.settings.dateTimeFormatOptions,
+                      this.settings.dateTimeFormatCustomString,
+                      this.settings.dateTimeTimezone
+                  )}`;
 
         const parts = [
             optionalShortHash,


### PR DESCRIPTION
This bug has been here since the very beginning when I implemented the line authoring into obsidian-git.

For unknown reasons, somtimes the `dom.remove()` fails and an exception is bubbled up - which makes the line authoring and afaik the whole plugin crash. Then the line authoring suddenly disappears and can't be brought back without a restart. It's hard to consistently reproduce it and I didn't brother too much with it back then - but this simply try and catch should fix it sufficiently.

Whenever I come across this error, I have to restart obsidian - but this isn't a good workaround for users who don't know what's happening. They'll probably just abandon this plugin or whatever.

Do you have any questions?