### PR TITLE
feat: collapse unchanged lines in split diff view

### DIFF
--- a/src/ui/diff/splitDiffView.ts
+++ b/src/ui/diff/splitDiffView.ts
@@ -359,8 +359,8 @@ export default class SplitDiffView extends ItemView {
                 b: bState,
                 a: aState,
                 collapseUnchanged: {
-                    minSize: 5,
-                    margin: 3,
+                    minSize: 6,
+                    margin: 4,
                 },
                 diffConfig: {
                     scanLimit: this.bIsEditable ? 1000 : 10000, // default is 500

--- a/src/ui/diff/splitDiffView.ts
+++ b/src/ui/diff/splitDiffView.ts
@@ -5,6 +5,10 @@ import { SimpleGit } from "src/gitManager/simpleGit";
 import type ObsidianGit from "src/main";
 import type { DiffViewState } from "src/types";
 
+import { history, indentWithTab, standardKeymap } from "@codemirror/commands";
+import { MergeView } from "@codemirror/merge";
+import { highlightSelectionMatches, search } from "@codemirror/search";
+import { EditorState, Transaction } from "@codemirror/state";
 import {
     drawSelection,
     EditorView,
@@ -12,10 +16,6 @@ import {
     lineNumbers,
     ViewPlugin,
 } from "@codemirror/view";
-import { EditorState, Transaction } from "@codemirror/state";
-import { MergeView } from "@codemirror/merge";
-import { history, indentWithTab, standardKeymap } from "@codemirror/commands";
-import { highlightSelectionMatches, search } from "@codemirror/search";
 import { GitError } from "simple-git";
 
 // This class is not extending `FileView', because it needs a `TFile`, which is not possible for dot files like `.gitignore`, which this editor should support as well.`
@@ -358,6 +358,10 @@ export default class SplitDiffView extends ItemView {
             this.mergeView = new MergeView({
                 b: bState,
                 a: aState,
+                collapseUnchanged: {
+                    minSize: 5,
+                    margin: 3,
+                },
                 diffConfig: {
                     scanLimit: this.bIsEditable ? 1000 : 10000, // default is 500
                 },

--- a/styles.css
+++ b/styles.css
@@ -590,3 +590,18 @@
 .git-obscure-prompt[git-is-obscured="false"] #git-show-password:after {
     -webkit-mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="svg-icon lucide-eye-off"><path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"></path><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"></path><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"></path><path d="m2 2 20 20"></path></svg>');
 }
+
+/* Override styling of Codemirror merge view "collapsed lines" indicator */
+.git-split-diff-view .ͼ2 .cm-collapsedLines {
+    background: linear-gradient(
+        to bottom,
+        transparent 0,
+        var(--background-secondary-alt) 35%,
+        var(--background-secondary-alt) 65%,
+        transparent 100%
+    );
+    border-radius: var(--radius-m);
+    color: var(--text-accent);
+    font-size: var(--font-small);
+    padding: var(--size-4-1) var(--size-4-1);
+}

--- a/styles.css
+++ b/styles.css
@@ -593,15 +593,13 @@
 
 /* Override styling of Codemirror merge view "collapsed lines" indicator */
 .git-split-diff-view .ͼ2 .cm-collapsedLines {
-    background: linear-gradient(
-        to bottom,
-        transparent 0,
-        var(--background-secondary-alt) 35%,
-        var(--background-secondary-alt) 65%,
-        transparent 100%
-    );
+    background: var(--interactive-normal);
     border-radius: var(--radius-m);
     color: var(--text-accent);
     font-size: var(--font-small);
     padding: var(--size-4-1) var(--size-4-1);
+}
+.git-split-diff-view .ͼ2 .cm-collapsedLines:hover {
+    background: var(--interactive-hover);
+    color: var(--text-accent-hover);
 }


### PR DESCRIPTION
Closes #881 

And believe me, the original styling of the indicator was even uglier.

![screenshots](https://github.com/user-attachments/assets/ff43e2f4-b509-4ed6-a701-860c188f5cac)
