### PR TITLE
feat: adding a setting for a tracked directory

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     authorInHistoryView: "hide",
     dateInHistoryView: false,
     diffStyle: "split",
+    trackedDirectory: "",
     lineAuthor: {
         show: false,
         followMovement: "inactive",

--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -861,14 +861,24 @@ export class IsomorphicGit extends GitManager {
     }: {
         walkers: Walker[];
         dir?: string;
-        }): Promise<WalkDifference[]> {
+    }): Promise<WalkDifference[]> {
+        const trackedDir = this.plugin.settings.trackedDirectory;
+
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const res = await this.wrapFS(
             git.walk({
                 ...this.getRepo(),
                 trees: walkers,
                 map: async function (filepath, [A, B]) {
-                    if (!worthWalking(filepath, base, this.plugin.settings.trackedDirectory)) {
+                    // Check if file is in tracked directory (if specified)
+                    if (trackedDir && trackedDir.length > 0 &&
+                        filepath !== trackedDir &&
+                        !filepath.startsWith(trackedDir + "/")) {
+                        return null;
+                    }
+
+                    // Original check with base path
+                    if (!worthWalking(filepath, base)) {
                         return null;
                     }
 

--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -861,14 +861,14 @@ export class IsomorphicGit extends GitManager {
     }: {
         walkers: Walker[];
         dir?: string;
-    }): Promise<WalkDifference[]> {
+        }): Promise<WalkDifference[]> {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const res = await this.wrapFS(
             git.walk({
                 ...this.getRepo(),
                 trees: walkers,
                 map: async function (filepath, [A, B]) {
-                    if (!worthWalking(filepath, base)) {
+                    if (!worthWalking(filepath, base, this.plugin.settings.trackedDirectory)) {
                         return null;
                     }
 
@@ -960,7 +960,7 @@ export class IsomorphicGit extends GitManager {
                             }
                         }
                         // match against base path
-                        if (!worthWalking(filepath, base)) {
+                        if (!worthWalking(filepath, base, this.plugin.settings.trackedDirectory)) {
                             return null;
                         }
                         // Late filter against file names

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -827,6 +827,20 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     })
             );
 
+        new Setting(containerEl)
+            .setName("Tracked directory within repository")
+            .setDesc("Specify a directory within your repository to track. Changes outside this directory will be ignored. Leave empty to track the entire repository.")
+            .addText((cb) => {
+                cb.setValue(plugin.settings.trackedDirectory);
+                cb.setPlaceholder("directory/subdirectory");
+                cb.onChange(async (value) => {
+                    plugin.settings.trackedDirectory = value;
+                    await plugin.saveSettings();
+                    // Trigger a refresh to update the UI
+                    plugin.refresh().catch((e) => plugin.displayError(e));
+                });
+            });
+
         new Setting(containerEl).setName("Support").setHeading();
         new Setting(containerEl)
             .setName("Donate")

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface ObsidianGitSettings {
     authorInHistoryView: ShowAuthorInHistoryView;
     dateInHistoryView: boolean;
     diffStyle: "git_unified" | "split";
+    trackedDirectory: string; // Directory within repo to track, empty means track all
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,9 @@ import { BINARY_EXTENSIONS } from "./constants";
 
 export const worthWalking = (filepath: string, root?: string, trackedDir?: string) => {
     // First check if the file is in the tracked directory, if specified
+    console.log("check tracked", trackedDir)
     if (trackedDir && trackedDir.length > 0 && !filepath.startsWith(trackedDir) && filepath !== trackedDir) {
+        console.log("not tracked", filepath)
         return false;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,13 @@ import type { App, RGB, WorkspaceLeaf } from "obsidian";
 import { Keymap, Menu, moment, TFile } from "obsidian";
 import { BINARY_EXTENSIONS } from "./constants";
 
-export const worthWalking = (filepath: string, root?: string) => {
+export const worthWalking = (filepath: string, root?: string, trackedDir?: string) => {
+    // First check if the file is in the tracked directory, if specified
+    if (trackedDir && trackedDir.length > 0 && !filepath.startsWith(trackedDir) && filepath !== trackedDir) {
+        return false;
+    }
+
+    // Then do the original check
     if (filepath === "." || root == null || root.length === 0 || root === ".") {
         return true;
     }


### PR DESCRIPTION
Adding a setting to specify a directory to track. Useful for when you have a monorepo with a docs subdirectory that you want to contribute to using Obsidian but want to track the rest of the repo in your usual git flow.

Untested, so I'll make this a draft PR, fix any bugs that crop up and swap to a real PR when it's ready.

If not interested in merging in the setting just lmk and I'll close the PR.