### PR TITLE
fix: Prevent jitter of refresh icon in mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,12 +17,12 @@
     padding: 0;
 }
 
-.workspace-leaf-content[data-type="git-view"] .nav-buttons-container {
-    min-height: 34px;
-}
-
 .workspace-leaf-content[data-type="git-history-view"] .view-content {
     padding: 0;
+}
+
+.loading {
+    overflow: hidden;
 }
 
 .loading > svg {


### PR DESCRIPTION
Closes #916

The root cause was that the .nav-buttons-container did not have a fixed minimum height, causing layout shifts when the loading animation started

Tested on:
- Obsidian Mobile (Android Pixel 8): Jitter is resolved.
- Obsidian Mobile (Android Emulator on Bluestack 720 x 1080 pixel): Jitter is resolved.
- Obsidian Desktop: No regression observed.