### PR TITLE
Bug Fix: (Tiny) Text Area Quotation 

### DIFF
--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -1316,7 +1316,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
 
         if (defaultValue !== storedValue) {
             // Doesn't add "" to saved strings
-            if (typeof storedValue === "string") {
+            if (typeof storedValue === "string" || typeof storedValue === "number" || typeof storedValue === "boolean") {
                 text.setValue(String(storedValue));
             }else {
                 text.setValue(JSON.stringify(storedValue));


### PR DESCRIPTION
In the settings, when the saved commitMessage or autoCommitMessage (Text Areas) load a saved value, it adds quotes to the start and end. If you edit the message and don't delete the quotes, it "correctly" escapes the quotes in the field and saves and repeats.

(See image at end, if I'm not being clear)

When loading the value, I've changed it to use String instead of JSON.Stringify so strings are passed as normal, only downside would be an object would show as [object] but this text value would never hold an object, just strings.

This is a tiny fix, No AI. umm. no unit tests either.

Thank you for your time (and great plugin).

<img width="771" height="226" alt="image" src="https://github.com/user-attachments/assets/89ccdcf3-7c54-44c0-a349-2237bc3969e3" />
