### PR TITLE
fix: file entries wrapping Source Control view on Win10 and 11

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -82,6 +82,7 @@
     align-items: center;
     justify-content: center;
     width: 11px;
+    flex-shrink: 0;
 }
 
 .git-tools .type[data-type="M"] {
@@ -101,6 +102,31 @@
 .workspace-leaf-content[data-type="git-view"] .tree-item-self,
 .workspace-leaf-content[data-type="git-history-view"] .tree-item-self {
     align-items: center;
+    flex-wrap: nowrap;
+    min-height: unset;
+}
+.workspace-leaf-content[data-type="git-view"] .tree-item-inner,
+.workspace-leaf-content[data-type="git-history-view"] .tree-item-inner {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.workspace-leaf-content[data-type="git-view"] .git-tools,
+.workspace-leaf-content[data-type="git-history-view"] .git-tools {
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+.workspace-leaf-content[data-type="git-view"] .nav-folder-title {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+}
+.workspace-leaf-content[data-type="git-view"] .nav-folder-title .tree-item-inner {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
 }
 
 .workspace-leaf-content[data-type="git-view"]


### PR DESCRIPTION
Hi, love the plug-in!

But in Win10 and 11 the control wrapping is off. I am a dinosaur thick client developer, but I was able to figure out enough to fix. I have included screenshots of the before and after. I did NOT check on the Mac. If you need this, let me know and I can find someone to check for me.

<img width="318" height="402" alt="cosmetic_issue" src="https://github.com/user-attachments/assets/a34fb3d3-ad5a-4d6c-b2d7-394a986038d1" />
<img width="318" height="280" alt="cosmetic_issue_after_fix" src="https://github.com/user-attachments/assets/90cda1b7-35cb-48d3-a1c4-546c193cd3c7" />