### PR TITLE
Add setting to show/hide git refs in history view

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     showFileMenu: true,
     authorInHistoryView: "hide",
     dateInHistoryView: false,
+    showGitRefsInHistoryView: true,
     diffStyle: "split",
     lineAuthor: {
         show: false,

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -491,6 +491,21 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     })
             );
 
+        new Setting(containerEl)
+            .setName("Show git refs")
+            .setDesc(
+                "Show git references (like HEAD, branches, tags) in the history view."
+            )
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(plugin.settings.showGitRefsInHistoryView)
+                    .onChange(async (value) => {
+                        plugin.settings.showGitRefsInHistoryView = value;
+                        await plugin.saveSettings();
+                        await plugin.refresh();
+                    })
+            );
+
         new Setting(containerEl).setName("Source control view").setHeading();
 
         new Setting(containerEl)

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,7 @@ export interface ObsidianGitSettings {
     showFileMenu: boolean;
     authorInHistoryView: ShowAuthorInHistoryView;
     dateInHistoryView: boolean;
+    showGitRefsInHistoryView: boolean;
     diffStyle: "git_unified" | "split";
 }
 

--- a/src/ui/history/components/logComponent.svelte
+++ b/src/ui/history/components/logComponent.svelte
@@ -47,7 +47,7 @@
     <div class="tree-item nav-folder" class:is-collapsed={isCollapsed}>
         <div
             class="tree-item-self is-clickable nav-folder-title"
-            aria-label={`${log.refs.length > 0 ? log.refs.join(", ") + "\n" : ""}${log.author?.name}
+            aria-label={`${plugin.settings.showGitRefsInHistoryView && log.refs.length > 0 ? log.refs.join(", ") + "\n" : ""}${log.author?.name}
 ${moment(log.date).format(plugin.settings.commitDateFormat)}
 ${log.message}`}
             data-tooltip-position={side}
@@ -72,7 +72,7 @@ ${log.message}`}
                 >
             </div>
             <div>
-                {#if log.refs.length > 0}
+                {#if plugin.settings.showGitRefsInHistoryView && log.refs.length > 0}
                     <div class="git-ref">
                         {log.refs.join(", ")}
                     </div>


### PR DESCRIPTION
When using git primarily for version control of notes in the vault rather than backup, it's not so useful to track where the refs (especially remotes) are, but they add clutter to the history view.

This MR adds a new setting "Show git refs" under "History view" heading defaulting to `true` (non-breaking change):
<img width="797" height="238" alt="image" src="https://github.com/user-attachments/assets/c0e5b551-13fa-4798-aa2c-f04de87d9901" />

Behaviour with toggle on:
<img width="304" height="313" alt="image" src="https://github.com/user-attachments/assets/aaeb0239-6155-415c-a7e1-12f7e42f15e0" />

and with toggle off:
<img width="301" height="277" alt="image" src="https://github.com/user-attachments/assets/da459fad-5bb3-4994-aa37-aa9991336458" />

Note: as for other settings in "History view", changes take effect only after window reload.