### PR TITLE
fix: automatically infer GIT_WORK_TREE from custom gitDir

### DIFF
--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -81,6 +81,18 @@ export class SimpleGit extends GitManager {
             }
             if (gitDir) {
                 process.env["GIT_DIR"] = gitDir;
+                if (!process.env["GIT_WORK_TREE"]) {
+                    const inferredWorkTree = path.dirname(gitDir);
+                    const cleanVault = normalizePath(vaultBasePath);
+                    const cleanWorkTree = normalizePath(inferredWorkTree);
+
+                    if (
+                        cleanVault === cleanWorkTree ||
+                        cleanVault.startsWith(cleanWorkTree + "/")
+                    ) {
+                        process.env["GIT_WORK_TREE"] = inferredWorkTree;
+                    }
+                }
             }
             for (const envVar of envVars) {
                 const [key, value] = envVar.split("=");


### PR DESCRIPTION
When a custom `gitDir` is configured, the plugin previously relied on the default work tree (the vault root). This caused issues for "detached vault" setups where the git repository root is a parent of the vault.

This change automatically sets `GIT_WORK_TREE` to the parent of the `gitDir` if it detects the vault is located inside that parent directory.

Example Use Case:

```
Directory Structure:
/ProjectRoot          (Git Repo Root)
  ├── .git/           (Git Dir)
  ├── full_guide.md   (Tracked file outside vault) <- some large markdown cause obsidian to crash, cant keep them inside vault
  └── local_vault/    (Obsidian Vault Root)
        └── note.md   (Tracked file inside vault)
```

Plugin Settings:
- Custom Git directory path: `.../ProjectRoot/.git`

Failure (Before):
- Git treats `local_vault` as root.
- `local_vault/note.md` is seen as `note.md`.
- `ProjectRoot/full_guide.md` is unseen/untracked.

Success (After):
- Git Work Tree is automatically set to `.../ProjectRoot`.
- `local_vault/note.md` is correctly seen as `local_vault/note.md`.