### PR TITLE
fix: obscure password prompt in isomorphic-git auth

### DIFF
--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -89,6 +89,7 @@ export class IsomorphicGit extends GitManager {
                     const password = await new GeneralModal(this.plugin, {
                         placeholder:
                             "Specify your password/personal access token",
+                        obscure: true,
                     }).openAndGetResult();
                     if (password) {
                         this.plugin.localStorage.setUsername(username);


### PR DESCRIPTION
Adds obscure: true to the password prompt in isomorphicGit.ts, masking passwords/PATs during authentication.

  Missed in 5dbd3cd which fixed this for simpleGit.ts but not isomorphicGit.