### PR TITLE
docs: fix MacOS header level in Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -60,6 +60,6 @@ $ flatpak run md.obsidian.Obsidian
 ```
 [Source of this snippet](https://github.com/flathub/md.obsidian.Obsidian/issues/5#issuecomment-736974662)
 
-## MacOS
+# MacOS
 
 Nothing specific.


### PR DESCRIPTION
Right now it’s shown in the ToC as a subsection under "Linux".