### PR TITLE
docs: Added MacOS installation details

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,4 +62,17 @@ $ flatpak run md.obsidian.Obsidian
 
 # MacOS
 
-Nothing specific.
+## Git Installation
+
+In order to install `git` on your Mac Computer please follow a suitable route explained in the [Official Git documentation](https://git-scm.com/install/mac)
+
+## Keychain
+
+Run the following to use the macOS keychain to store your credentials.
+
+```zsh
+git config --global credential.helper osxkeychain
+```
+
+>[!info]
+> You have to complete a **single authenticated action** (either clone, pull or push) after setting the helper in the terminal. Once done, you should be able to sync Obsidian without any issues.


### PR DESCRIPTION
As discussed in #1030 expanded **MacOS** section to include:
- a link to the [Official Git documentation](https://git-scm.com/install/mac)
- a requirement to manually run authenticated action once to get Obsidian sync working without further authentication calls.