### PR TITLE
feat: Default {{hostname}} placeholder to OS hostname when not explicitly configured

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -22,6 +22,7 @@ const context = await esbuild.context({
         "electron",
         "child_process",
         "fs",
+        "os",
         "path",
         "moment",
         "node:events",

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,3 +1,4 @@
+import { hostname as osHostname } from "os";
 import { type App, moment } from "obsidian";
 import type ObsidianGit from "../main";
 import type {
@@ -274,7 +275,14 @@ export abstract class GitManager {
             template = template.replace("{{numFiles}}", String(numFiles));
         }
         if (template.includes("{{hostname}}")) {
-            const hostname = this.plugin.localStorage.getHostname() || "";
+            let hostname = this.plugin.localStorage.getHostname() || "";
+            if (!hostname) {
+                try {
+                    hostname = osHostname();
+                } catch {
+                    // os module not available (e.g., on mobile)
+                }
+            }
             template = template.replace("{{hostname}}", hostname);
         }
 

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,5 +1,5 @@
 import { hostname as osHostname } from "os";
-import { type App, moment } from "obsidian";
+import { type App, moment, Platform } from "obsidian";
 import type ObsidianGit from "../main";
 import type {
     BranchInfo,
@@ -276,12 +276,8 @@ export abstract class GitManager {
         }
         if (template.includes("{{hostname}}")) {
             let hostname = this.plugin.localStorage.getHostname() || "";
-            if (!hostname) {
-                try {
-                    hostname = osHostname();
-                } catch {
-                    // os module not available (e.g., on mobile)
-                }
+            if (!hostname && Platform.isDesktopApp) {
+                hostname = osHostname();
             }
             template = template.replace("{{hostname}}", hostname);
         }

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -347,7 +347,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
             new Setting(containerEl)
                 .setName("{{hostname}} placeholder replacement")
                 .setDesc(
-                    "Specify custom hostname for every device. Defaults to the OS hostname if not set."
+                    "Specify custom hostname for every device. Defaults to the OS hostname if not set on desktop."
                 )
                 .addText((text) =>
                     text

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -346,7 +346,9 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
 
             new Setting(containerEl)
                 .setName("{{hostname}} placeholder replacement")
-                .setDesc("Specify custom hostname for every device.")
+                .setDesc(
+                    "Specify custom hostname for every device. Defaults to the OS hostname if not set."
+                )
                 .addText((text) =>
                     text
                         .setValue(plugin.localStorage.getHostname() ?? "")


### PR DESCRIPTION
* feat: fall back to OS hostname when {{hostname}} placeholder is not configured

When the {{hostname}} placeholder is used in commit messages but no custom hostname is set in localStorage, fall back to the OS hostname via os.hostname(). This handles the case gracefully on mobile where the os module is unavailable.

Tested locally. Resolves #1043.