### PR TITLE
fix: prevent  "detached HEAD" state after using "Switch to remote branch" command

### DIFF
--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -901,6 +901,8 @@ export class SimpleGit extends GitManager {
     }
 
     private async getLocalBranchUpstream(localBranchName: string): Promise<string | undefined> {
+        // Returns the configured upstream ref for a local branch (e.g. `origin/main`), using
+        // Return undefined when no upstream exists or if git throws an error.
         try {
             const upstream = await this.git.raw([
                 "rev-parse",
@@ -919,6 +921,16 @@ export class SimpleGit extends GitManager {
         remote: string,
         existingBranchNames: string[]
     ): string {
+        // Chooses a local branch name that does not collide with `existingBranchNames`.
+        // Prefers `remoteBranchName`, then `<remoteBranchName>-<remote>`, then that base with `-1`, `-2`, …
+        //
+        // Ex.: for a remote branch `origin/my-branch`
+        // - `my-branch` is preferred
+        // - `my-branch-origin` is next
+        // - `my-branch-origin-1` is next
+        // - `my-branch-origin-2` is next
+        // - etc.
+
         const preferred = remoteBranchName;
         if (!existingBranchNames.includes(preferred)) {
             return preferred;
@@ -935,25 +947,35 @@ export class SimpleGit extends GitManager {
 
     async checkout(branch: string, remote?: string): Promise<void> {
         if (remote) {
+            // If we're trying to checkout a remote branch we'll either switch to an existing local branch that
+            // already tracks it, or create a new local branch from the remote tip (name may be disambiguated).
             const remoteBranch = `${remote}/${branch}`;
             const branchInfo = await this.branchInfo();
             const localBranchExists = branchInfo.branches.includes(branch);
 
+            // We found a local branch with the "correct" name, but it might track 
+            // a different remote, so we'll double check before proceeding.
             const existingBranchTracksRemote =
                 localBranchExists &&
                 (await this.getLocalBranchUpstream(branch)) === remoteBranch;
 
             if (existingBranchTracksRemote) {
+                // The local branch already exists AND it tracked the correct remote, so we can simply switch to it.
                 await this.git.checkout(branch);
             } else {
+                // The local branch doesn't exist or it tracks a different remote, so we'll need to create a new local branch.
+                // First we need to find a suitable name for the new local branch.
                 const localBranchName = this.getAvailableLocalBranchName(
                     branch,
                     remote,
                     branchInfo.branches
                 );
+
+                // Finally, we can use `git checkout -b` to create the new local branch and set it to track the remote branch.
                 await this.git.checkout(["-b", localBranchName, remoteBranch]);
             }
         } else {
+            // Checkout an existing local branch (no remote specified).
             await this.git.checkout(branch);
         }
 

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -900,7 +900,9 @@ export class SimpleGit extends GitManager {
         return this.git.show([commitHash + ":" + path]);
     }
 
-    private async getLocalBranchUpstream(localBranchName: string): Promise<string | undefined> {
+    private async getLocalBranchUpstream(
+        localBranchName: string
+    ): Promise<string | undefined> {
         // Returns the configured upstream ref for a local branch (e.g. `origin/main`), using
         // Return undefined when no upstream exists or if git throws an error.
         try {
@@ -953,7 +955,7 @@ export class SimpleGit extends GitManager {
             const branchInfo = await this.branchInfo();
             const localBranchExists = branchInfo.branches.includes(branch);
 
-            // We found a local branch with the "correct" name, but it might track 
+            // We found a local branch with the "correct" name, but it might track
             // a different remote, so we'll double check before proceeding.
             const existingBranchTracksRemote =
                 localBranchExists &&

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -902,9 +902,18 @@ export class SimpleGit extends GitManager {
 
     async checkout(branch: string, remote?: string): Promise<void> {
         if (remote) {
-            branch = `${remote}/${branch}`;
+            const remoteBranch = `${remote}/${branch}`;
+            const branchInfo = await this.branchInfo();
+
+            if (branchInfo.branches.includes(branch)) {
+                await this.git.checkout(branch);
+            } else {
+                await this.git.checkout(["-b", branch, remoteBranch]);
+            }
+        } else {
+            await this.git.checkout(branch);
         }
-        await this.git.checkout(branch);
+
         if (this.plugin.settings.submoduleRecurseCheckout) {
             const submodulePaths = await this.getSubmodulePaths();
             for (const submodulePath of submodulePaths) {

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -900,15 +900,58 @@ export class SimpleGit extends GitManager {
         return this.git.show([commitHash + ":" + path]);
     }
 
+    private async getLocalBranchUpstream(localBranchName: string): Promise<string | undefined> {
+        try {
+            const upstream = await this.git.raw([
+                "rev-parse",
+                "--abbrev-ref",
+                `${localBranchName}@{upstream}`,
+            ]);
+            const trimmed = upstream.trim();
+            return trimmed.length > 0 ? trimmed : undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    private getAvailableLocalBranchName(
+        remoteBranchName: string,
+        remote: string,
+        existingBranchNames: string[]
+    ): string {
+        const preferred = remoteBranchName;
+        if (!existingBranchNames.includes(preferred)) {
+            return preferred;
+        }
+        const base = `${remoteBranchName}-${remote}`;
+        let candidate = base;
+        let n = 0;
+        while (existingBranchNames.includes(candidate)) {
+            n += 1;
+            candidate = `${base}-${n}`;
+        }
+        return candidate;
+    }
+
     async checkout(branch: string, remote?: string): Promise<void> {
         if (remote) {
             const remoteBranch = `${remote}/${branch}`;
             const branchInfo = await this.branchInfo();
+            const localBranchExists = branchInfo.branches.includes(branch);
 
-            if (branchInfo.branches.includes(branch)) {
+            const existingBranchTracksRemote =
+                localBranchExists &&
+                (await this.getLocalBranchUpstream(branch)) === remoteBranch;
+
+            if (existingBranchTracksRemote) {
                 await this.git.checkout(branch);
             } else {
-                await this.git.checkout(["-b", branch, remoteBranch]);
+                const localBranchName = this.getAvailableLocalBranchName(
+                    branch,
+                    remote,
+                    branchInfo.branches
+                );
+                await this.git.checkout(["-b", localBranchName, remoteBranch]);
             }
         } else {
             await this.git.checkout(branch);


### PR DESCRIPTION
When using the "Switch to remote branch" command the git repository goes into "detached head" mode because obsidian-git is calling `git checkout origin/<branch_name>` which does not create a local branch that tracks the remote branch.

The fix for it is simple: if a local branch tracking the remote branch does not exists yet, use `git checkout -b <branch> origin/<branch>` to checkout the remote branch AND create a local branch with the same name that tracks the remote branch.

If a local branch with the same name already exists AND it tracks the remote branch, then simply call `git checkout <branch>`