### PR TITLE
fix: set GIT_WORK_TREE when using custom git directory

### DIFF
--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -82,6 +82,7 @@ export class SimpleGit extends GitManager {
             }
             if (gitDir) {
                 envs["GIT_DIR"] = gitDir;
+                envs["GIT_WORK_TREE"] = basePath;
             }
             for (const envVar of envVars) {
                 const [key, value] = envVar.split("=");


### PR DESCRIPTION
I have a scenario where I don't want the .git directory to be inside the vault. The reason is because I also have Google Drive syncing this vault Automatically. And I don't want Google Drive to sync the Git files. (Google Drive doesn't have any sort of files-to-ignore configuration)

Unfortunately everything I tried wasn't working. I know this plugin already has support for different Git repo, but with an external git repo you have to specify both the GIT_DIR and the GIT_WORK_TREE explicitly in the environment or through command line options. And this plugin doesn't support that. 

This PR fixes that by adding support for the GIT_WORK_TREE. It's not necessary to specify it explicitly as it will default to the vault/base directory. It's harmless to have it present in other scenarios because it will still have the correct value, the base path. 

> [!NOTE]
> Running `git` from within the working directory (basepath) used to be enough, some 15 years ago, but no longer. Also this is completely unrelated to `git worktree` support. 