### PR TITLE
fix: fall back to git CLI when simple-git fails to detect branch

### DIFF
--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -837,9 +837,24 @@ export class SimpleGit extends GitManager {
         const status = await this.git.status();
         const branches = await this.git.branch(["--no-color"]);
 
+        // simple-git's `status` parser occasionally fails to extract the
+        // branch line (`## <current>...<tracking>`) from `git status
+        // --porcelain -b -u --null` output, leaving `current`/`tracking` as
+        // `null`. When that happens, both fields end up as `undefined` here
+        // and downstream `git rev-parse <undefined>` calls explode with
+        // `fatal: ambiguous argument 'undefined'`. Fall back to information
+        // from `git branch --no-color` (for current) and
+        // `git rev-parse --abbrev-ref <current>@{upstream}` (for tracking),
+        // which always work when a branch and upstream are configured.
+        const current = status.current || branches.current || undefined;
+        let tracking = status.tracking || undefined;
+        if (!tracking && current) {
+            tracking = await this.getLocalBranchUpstream(current);
+        }
+
         return {
-            current: status.current || undefined,
-            tracking: status.tracking || undefined,
+            current,
+            tracking,
             branches: branches.all,
         };
     }


### PR DESCRIPTION
## Summary

Fixes #1039.

`SimpleGit.branchInfo()` relies on `simple-git`'s `status` parser to populate `current` and `tracking`. In some setups that parser silently returns `null` for both even when the branch and its upstream are correctly configured. The values then get propagated as `undefined` to the non-null-asserted call sites in `pull()`:

```ts
const localCommit = await this.git.revparse([branchInfo.current!]);
// ...
const upstreamCommit = await this.git.revparse([branchInfo.tracking!]);
```

`undefined` ends up serialized into the spawn args and git fails with:

```
fatal: ambiguous argument 'undefined': unknown revision or path not in the working tree.
```

This matches every report in #1039 (same stack through `attemptRemoteTask` → `handleTaskData` → plugin `task.error` → throw).

## Fix

In `branchInfo()`, fall back to data sources that don't depend on `git status --porcelain -b -u --null` parsing:

- **current** — use `branches.current` from the `git branch --no-color` call that's already made in the same function.
- **tracking** — call the existing `getLocalBranchUpstream(current)` helper, which runs `git rev-parse --abbrev-ref <branch>@{upstream}`.

Both fallbacks only kick in when `status` returns null, so the happy path is unchanged.

## Test plan

- [x] `pnpm tsc` (no errors)
- [x] `pnpm prettier --check` on the touched file
- [x] `pnpm eslint` on the touched file
- [x] Manually verified on an affected vault: before — every commit-and-sync produced `Error: undefined / fatal: ambiguous argument 'undefined'`; after — pull/sync runs cleanly and reports `Pull: Everything is up-to-date` / `Pulled N files from remote`.