### PR TITLE
fix: improve mobile debug and credential handling

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     pullBeforePush: true,
     disablePopups: false,
     showErrorNotices: true,
+    debugLogging: false,
     disablePopupsForNoChanges: false,
     listChangedFilesInMessageBody: false,
     showStatusBar: true,

--- a/src/gitManager/myAdapter.ts
+++ b/src/gitManager/myAdapter.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/require-await */
-/* eslint-disable @typescript-eslint/only-throw-error */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -39,30 +38,51 @@ export class MyAdapter {
         this.maybeLog("Read: " + path + JSON.stringify(opts));
         if (opts == "utf8" || opts.encoding == "utf8") {
             const file = this.vault.getAbstractFileByPath(path);
+            let data: string | undefined | null;
             if (file instanceof TFile) {
                 this.maybeLog("Reuse");
 
-                return this.vault.read(file);
+                data = await this.vault.read(file);
             } else {
-                return this.adapter.read(path);
+                data = await this.adapter.read(path);
             }
+            if (data == null) {
+                this.logMissingRead(path, "text");
+            }
+            return data;
         } else {
             if (path.endsWith(this.gitDir + "/index")) {
                 if (this.plugin.settings.basePath != this.lastBasePath) {
                     this.clearIndex();
                     this.lastBasePath = this.plugin.settings.basePath;
-                    return this.adapter.readBinary(path);
+                    const data = await this.adapter.readBinary(path);
+                    if (data == null) {
+                        this.logMissingRead(path, "binary");
+                    }
+                    return data;
                 }
-                return this.index ?? this.adapter.readBinary(path);
+                if (this.index != undefined) {
+                    return this.index;
+                }
+                const data = await this.adapter.readBinary(path);
+                if (data == null) {
+                    this.logMissingRead(path, "binary");
+                }
+                return data;
             }
             const file = this.vault.getAbstractFileByPath(path);
+            let data: ArrayBuffer | undefined | null;
             if (file instanceof TFile) {
                 this.maybeLog("Reuse");
 
-                return this.vault.readBinary(file);
+                data = await this.vault.readBinary(file);
             } else {
-                return this.adapter.readBinary(path);
+                data = await this.adapter.readBinary(path);
             }
+            if (data == null) {
+                this.logMissingRead(path, "binary");
+            }
+            return data;
         }
     }
     async writeFile(path: string, data: string | ArrayBuffer) {
@@ -130,7 +150,9 @@ export class MyAdapter {
             } else {
                 const stat = await this.adapter.stat(path);
                 if (stat == undefined) {
-                    throw { code: "ENOENT" };
+                    throw this.notFound(
+                        `ENOENT: no such file or directory, lstat '${path}'`
+                    );
                 }
                 this.indexctime = stat.ctime;
                 this.indexmtime = stat.mtime;
@@ -173,7 +195,9 @@ export class MyAdapter {
                 };
             } else {
                 // used to determine whether a file exists or not
-                throw { code: "ENOENT" };
+                throw this.notFound(
+                    `ENOENT: no such file or directory, lstat '${path}'`
+                );
             }
         }
     }
@@ -214,6 +238,20 @@ export class MyAdapter {
 
     private get gitDir(): string {
         return this.plugin.settings.gitDir || ".git";
+    }
+
+    private logMissingRead(path: string, mode: "text" | "binary"): never {
+        this.plugin.debugLog("isomorphic-git readFile:missing", {
+            path,
+            mode,
+        });
+        throw this.notFound(`Could not read ${path}`);
+    }
+
+    private notFound(message: string): Error {
+        const error = new Error(message);
+        Object.assign(error, { code: "ENOENT" });
+        return error;
     }
 
     private maybeLog(_: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,9 @@ import { DiscardModal, type DiscardResult } from "./ui/modals/discardModal";
 import { HunkActions } from "./editor/signs/hunkActions";
 import { EditorIntegration } from "./editor/editorIntegration";
 
+const DEBUG_LOG_FILE = "plugin/log/git-log.md";
+const DEBUG_LOG_MAX_BYTES = 256 * 1024;
+
 export default class ObsidianGit extends Plugin {
     gitManager: GitManager;
     automaticsManager = new AutomaticsManager(this);
@@ -489,7 +492,7 @@ export default class ObsidianGit extends Plugin {
             await this.saveSettings();
         }
         if (this.settings.username != undefined) {
-            this.localStorage.setPassword(this.settings.username);
+            this.localStorage.setUsername(this.settings.username);
             this.settings.username = undefined;
             await this.saveSettings();
         }
@@ -1622,6 +1625,10 @@ I strongly recommend to use "Source mode" for viewing the conflicted files. For 
         }
 
         this.setPluginState({ gitAction: CurrentGitAction.idle });
+        this.debugLog("displayError", {
+            message: error.message,
+            stack: error.stack,
+        });
         if (this.settings.showErrorNotices) {
             new Notice(error.message, timeout);
         }
@@ -1631,5 +1638,76 @@ I strongly recommend to use "Source mode" for viewing the conflicted files. For 
 
     log(...data: unknown[]) {
         console.log(`${this.manifest.id}:`, ...data);
+    }
+
+    debugLog(...data: unknown[]) {
+        this.log(...data);
+        void this.appendDebugLog(data);
+    }
+
+    private async appendDebugLog(data: unknown[]): Promise<void> {
+        if (!this.settings?.debugLogging) {
+            return;
+        }
+        try {
+            const timestamp = new Date().toISOString();
+            const line = `${timestamp} ${data
+                .map((item) => this.formatDebugValue(item))
+                .join(" ")}\n`;
+            const adapter = this.app.vault.adapter;
+            const logDir = DEBUG_LOG_FILE.split("/").slice(0, -1).join("/");
+            if (logDir && !(await adapter.exists(logDir))) {
+                await adapter.mkdir(logDir);
+            }
+            if (await adapter.exists(DEBUG_LOG_FILE)) {
+                const stat = await adapter.stat(DEBUG_LOG_FILE);
+                if ((stat?.size ?? 0) > DEBUG_LOG_MAX_BYTES) {
+                    const currentLog = await adapter.read(DEBUG_LOG_FILE);
+                    await adapter.write(
+                        DEBUG_LOG_FILE,
+                        currentLog.slice(-DEBUG_LOG_MAX_BYTES / 2)
+                    );
+                }
+                await adapter.append(DEBUG_LOG_FILE, line);
+            } else {
+                await adapter.write(DEBUG_LOG_FILE, line);
+            }
+        } catch (error) {
+            console.error(
+                `${this.manifest.id}: failed to write debug log`,
+                error
+            );
+        }
+    }
+
+    private redactDebugValue(value: unknown): unknown {
+        if (Array.isArray(value)) {
+            return value.map((item) => this.redactDebugValue(item));
+        }
+        if (value == null || typeof value !== "object") {
+            return value;
+        }
+        return Object.fromEntries(
+            Object.entries(value).map(([key, item]) => [
+                key,
+                /password|token|secret|credential|authorization/i.test(key)
+                    ? "***"
+                    : this.redactDebugValue(item),
+            ])
+        );
+    }
+
+    private formatDebugValue(value: unknown): string {
+        if (typeof value === "string") {
+            return this.redactDebugString(value);
+        }
+        return JSON.stringify(this.redactDebugValue(value));
+    }
+
+    private redactDebugString(value: string): string {
+        return value.replace(
+            /((?:password|token|secret|credential|authorization)[^=:\s]*\s*[=:]\s*)[^\s&]+/gi,
+            "$1***"
+        );
     }
 }

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -693,6 +693,18 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     })
             );
 
+        new Setting(containerEl)
+            .setName("Debug logging")
+            .setDesc("Write debug logs to plugin/log/git-log.md.")
+            .addToggle((toggle) =>
+                toggle
+                    .setValue(plugin.settings.debugLogging)
+                    .onChange(async (value) => {
+                        plugin.settings.debugLogging = value;
+                        await plugin.saveSettings();
+                    })
+            );
+
         if (!plugin.settings.disablePopups)
             new Setting(containerEl)
                 .setName("Hide notifications for no changes")
@@ -788,9 +800,11 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     "Type in your password. You won't be able to see it again."
                 )
                 .addText((cb) => {
+                    cb.inputEl.type = "password";
                     cb.inputEl.autocapitalize = "off";
                     cb.inputEl.autocomplete = "off";
                     cb.inputEl.spellcheck = false;
+                    cb.setValue(plugin.localStorage.getPassword() ?? "");
                     cb.onChange((value) => {
                         plugin.localStorage.setPassword(value);
                     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface ObsidianGitSettings {
      * Whether messages from {@link ObsidianGit.displayError} should be shown
      */
     showErrorNotices: boolean;
+    debugLogging: boolean;
     disablePopupsForNoChanges: boolean;
     listChangedFilesInMessageBody: boolean;
     showStatusBar: boolean;


### PR DESCRIPTION
## Summary
- add an opt-in debug logging setting that writes redacted diagnostics to `plugin/log/git-log.md`
- mask the stored password/token field in settings and fix migration of the legacy username setting
- make the mobile isomorphic-git adapter throw proper `ENOENT` errors for missing reads/stat calls instead of returning null-like values or bare objects

## Duplicate check
- checked open PRs and recent merged PRs; no open PR covers debug logging, settings password/token masking, or mobile adapter missing-read `ENOENT` handling
- related merged PR #1007 only obscures the isomorphic-git auth prompt, not the stored settings password/token field

## Test plan
- `pnpm run tsc`
- `pnpm run svelte`
- `pnpm run format`
- `pnpm run lint`
- `pnpm run build`