### PR TITLE
fix: binary writes in mobile git adapter

### DIFF
--- a/src/gitManager/myAdapter.ts
+++ b/src/gitManager/myAdapter.ts
@@ -7,6 +7,8 @@ import type { DataAdapter, Vault } from "obsidian";
 import { normalizePath, TFile } from "obsidian";
 import type ObsidianGit from "../main";
 
+type BinaryData = ArrayBuffer | ArrayBufferView;
+
 export class MyAdapter {
     promises: any = {};
     adapter: DataAdapter;
@@ -65,7 +67,7 @@ export class MyAdapter {
             }
         }
     }
-    async writeFile(path: string, data: string | ArrayBuffer) {
+    async writeFile(path: string, data: string | BinaryData) {
         this.maybeLog("Write: " + path);
 
         if (typeof data === "string") {
@@ -76,16 +78,17 @@ export class MyAdapter {
                 return this.adapter.write(path, data);
             }
         } else {
+            const binaryData = toArrayBuffer(data);
             if (path.endsWith(this.gitDir + "/index")) {
-                this.index = data;
+                this.index = binaryData;
                 this.indexmtime = Date.now();
                 // this.adapter.writeBinary(path, data);
             } else {
                 const file = this.vault.getAbstractFileByPath(path);
                 if (file instanceof TFile) {
-                    return this.vault.modifyBinary(file, data);
+                    return this.vault.modifyBinary(file, binaryData);
                 } else {
-                    return this.adapter.writeBinary(path, data);
+                    return this.adapter.writeBinary(path, binaryData);
                 }
             }
         }
@@ -219,4 +222,22 @@ export class MyAdapter {
     private maybeLog(_: string) {
         // console.log(text);
     }
+}
+
+function toArrayBuffer(data: BinaryData): ArrayBuffer {
+    if (data instanceof ArrayBuffer) {
+        return data;
+    }
+
+    // Obsidian's binary APIs expect an ArrayBuffer, while isomorphic-git may pass Buffer/Uint8Array views.
+    if (
+        data.buffer instanceof ArrayBuffer &&
+        data.byteOffset === 0 &&
+        data.byteLength === data.buffer.byteLength
+    ) {
+        return data.buffer;
+    }
+
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice()
+        .buffer;
 }


### PR DESCRIPTION
## Summary

This normalizes binary data before passing it to Obsidian's binary file APIs in the isomorphic-git adapter.

`isomorphic-git` can call the fs `writeFile` implementation with `Buffer` / `Uint8Array` views for pack/index data, while Obsidian's `writeBinary` and `modifyBinary` APIs expect an `ArrayBuffer`. The adapter now converts `ArrayBufferView` values to an exact `ArrayBuffer` before writing them.

## Why

Recent `isomorphic-git` versions added packfile integrity validation. That can surface previously silent binary persistence problems as errors like:

`Packfile payload corrupted: calculated ... but expected ... The packfile may have been tampered with.`

This is relevant to mobile clone/fetch failures reported in #1085 and related mobile clone/fetch reports in #642.

## Validation

- `pnpm run tsc`
- `pnpm run svelte`
- `pnpm run lint`
- `pnpm run format`
- `pnpm run build`
- Ran a local adapter-boundary check that bundles `MyAdapter` and verifies `Uint8Array` / `Buffer.subarray()` writes are converted to exact-length `ArrayBuffer` values.
- Ran a local smart-HTTP fixture with `isomorphic-git@1.37.4` through `MyAdapter`: shallow clone and fetch completed, with `.pack` and `.idx` written via an Obsidian-like `writeBinary` implementation that rejects non-`ArrayBuffer` values.

## Mobile testing

This has now been verified on a real mobile Obsidian environment by installing the fork test build and retrying the clone/fetch flow that previously failed with `Packfile payload corrupted`.

To make mobile verification easier, I published a fork pre-release with `main.js`, `manifest.json`, and `styles.css`:

https://github.com/TadokoroYuki/obsidian-git/releases/tag/codex-mobile-packfile-test-a0509f1

Additional device coverage is still welcome, especially across both iOS and Android clone/fetch paths.
