### PR TITLE
fix: prevent corrupted packfiles from compressed fetch responses on mobile

### DIFF
--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -119,16 +119,33 @@ export class IsomorphicGit extends GitManager {
                     const res = await requestUrl({
                         url,
                         method,
-                        headers,
+                        // Ask the server not to compress the response. The
+                        // packfile parser needs the exact raw bytes; if a
+                        // server or proxy gzips the response and the platform
+                        // does not transparently inflate it, the packfile is
+                        // persisted corrupted and only fails later with
+                        // "Packfile payload corrupted".
+                        headers: { "Accept-Encoding": "identity", ...headers },
                         body: collectedBody,
                         throw: false,
                     });
+
+                    // Defense in depth: if the response still arrived gzipped
+                    // (a server/proxy ignored the request and the platform did
+                    // not inflate it), inflate it ourselves. This is keyed on
+                    // the gzip magic bytes rather than the `Content-Encoding`
+                    // header on purpose: some platforms auto-inflate but leave
+                    // the header in place, and trusting it would double-inflate
+                    // and corrupt the body.
+                    const responseBuffer = await inflateIfGzipped(
+                        res.arrayBuffer
+                    );
 
                     return {
                         url,
                         method,
                         headers: res.headers,
-                        body: arrayBufferToAsyncIterator(res.arrayBuffer),
+                        body: arrayBufferToAsyncIterator(responseBuffer),
                         statusCode: res.status,
                         statusMessage: res.status.toString(),
                     };
@@ -1320,4 +1337,27 @@ async function asyncIteratorToArrayBuffer(
 
     const response = new Response(stream);
     return await response.arrayBuffer();
+}
+
+// If `buffer` starts with the gzip magic bytes (0x1f 0x8b), inflate it and
+// return the decompressed bytes; otherwise return it unchanged. A valid git
+// smart-HTTP response body never starts with those bytes (it begins with an
+// ASCII pkt-line length or "PACK"), so this check is unambiguous. Keyed on the
+// content rather than the `Content-Encoding` header because some platforms
+// transparently inflate the body while leaving the header in place.
+async function inflateIfGzipped(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+    const bytes = new Uint8Array(buffer);
+    if (bytes.length < 2 || bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
+        return buffer;
+    }
+    try {
+        const stream = new Blob([buffer])
+            .stream()
+            .pipeThrough(new DecompressionStream("gzip"));
+        return await new Response(stream).arrayBuffer();
+    } catch {
+        // If decompression is unavailable or fails, fall back to the original
+        // bytes so behavior is no worse than before.
+        return buffer;
+    }
 }


### PR DESCRIPTION
## Problem

On mobile, fetch/clone/pull can fail with:

```
An internal error caused this command to fail.
... Packfile payload corrupted: calculated <sha> but expected <sha>.
The packfile may have been tampered with.
```

![Packfile payload corrupted error on mobile](https://raw.githubusercontent.com/Narcolepsyy/obsidian-git/assets/packfile-error/docs/img/packfile-error.png)

*Error shown on mobile after a fetch, before this fix. Raised by isomorphic-git at the packfile payload-SHA verification step.*

This is thrown by isomorphic-git's packfile integrity check — but the corruption originates in the **HTTP receive path**, not the filesystem adapter (so it is unrelated to, and not covered by, the binary-write normalization in #1090).

The smart-HTTP response is collected through Obsidian's `requestUrl` and handed to the packfile parser as an `ArrayBuffer`. If a server or proxy returns a **gzip-compressed** body and the platform does not transparently inflate it, the still-compressed (or otherwise altered) bytes get written as a packfile that passes the trailer check but fails the payload SHA later, when its objects are read. A valid git smart-HTTP body begins with an ASCII pkt-line length or `PACK` — never the gzip magic bytes — so a body starting with `1f 8b` is unambiguously a response that should have been inflated.

## Fix

Harden the HTTP client in `getRepo()` in two layers:

1. **Request identity encoding** — send `Accept-Encoding: identity` so the server is asked not to compress the response. Caller-supplied headers still override it.
2. **Detect-and-inflate (defense in depth)** — if the response body still starts with the gzip magic bytes (`0x1f 0x8b`), inflate it with `DecompressionStream("gzip")` before handing it on.

The inflate is keyed on the **actual body bytes, not the `Content-Encoding` header**, on purpose: some platforms transparently inflate the body while leaving the header in place, and trusting the header would double-inflate and *introduce* the very corruption this fixes. If decompression is unavailable or fails, it falls back to the original bytes, so behavior is never worse than before.

## Testing

- `pnpm run all` (tsc + svelte-check + prettier + eslint) and `pnpm run build` all pass.
- The `inflateIfGzipped` logic was exercised in a Node harness:
  - gzipped packfile-like payload → inflated back to the exact original bytes;
  - plain pkt-line body and bodies starting with `PACK` → passed through unchanged;
  - empty and single-byte buffers → no crash, passed through.

## Notes / caveats

- This prevents *new* corruption on the receive path. It does not repair a pack that is already corrupt on disk or on the remote — for that, a re-clone (or server-side repack) is still required. In the reporter's case a re-clone restored normal operation, which is consistent with a transient compressed/truncated transfer.
- I can't exercise the full Obsidian mobile networking stack from here, so on-device verification of clone/fetch against the affected remote would be a good final check before merge.
- Separate from #1097 (the criss-cross merge fallback); these touch different code paths and can be reviewed independently.
