### PR TITLE
feat: add option to squash unpushed commits before push

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     autoCommitOnlyStaged: false,
     disablePush: false,
     pullBeforePush: true,
+    squashCommitsBeforePush: false,
     disablePopups: false,
     showErrorNotices: true,
     disablePopupsForNoChanges: false,

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -823,7 +823,8 @@ export class SimpleGit extends GitManager {
      * commit. Only unpushed history is rewritten (HEAD is soft-reset onto the
      * tracking branch), so this never requires a force-push and is safe across
      * multiple devices. No-op if there is no tracking branch, fewer than two
-     * unpushed commits, or a merge commit is present in the unpushed range.
+     * unpushed commits, a merge commit is present in the unpushed range, or
+     * there are staged but uncommitted changes.
      */
     async squashAllUnpushedCommits({
         message,
@@ -833,6 +834,16 @@ export class SimpleGit extends GitManager {
         const status = await this.git.status();
         const trackingBranch = status.tracking;
         if (!trackingBranch || !status.current) {
+            return;
+        }
+        // A soft reset keeps the index, so any staged but uncommitted changes
+        // would be folded into the squash commit, silently committing work the
+        // user did not intend to. Abort the squash and let the push proceed
+        // with the existing history untouched.
+        const staged = (
+            await this.git.raw(["diff", "--cached", "--name-only"])
+        ).trim();
+        if (staged.length > 0) {
             return;
         }
         const range = `${trackingBranch}..HEAD`;

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -822,18 +822,27 @@ export class SimpleGit extends GitManager {
      * Squashes all local commits that have not been pushed yet into a single
      * commit. Only unpushed history is rewritten (HEAD is soft-reset onto the
      * tracking branch), so this never requires a force-push and is safe across
-     * multiple devices. No-op if there is no tracking branch, fewer than two
-     * unpushed commits, a merge commit is present in the unpushed range, or
-     * there are staged but uncommitted changes.
+     * multiple devices. The squash commit reuses the message of the most recent
+     * unpushed commit, so a custom, modal or script-derived commit message is
+     * preserved instead of being overwritten by the auto-commit template.
+     * No-op if there is no tracking branch, the tracking branch no longer
+     * exists on the remote, there are fewer than two unpushed commits, a merge
+     * commit is present in the unpushed range, or there are staged but
+     * uncommitted changes.
      */
-    async squashAllUnpushedCommits({
-        message,
-    }: {
-        message: string;
-    }): Promise<void> {
+    async squashAllUnpushedCommits(): Promise<void> {
         const status = await this.git.status();
         const trackingBranch = status.tracking;
         if (!trackingBranch || !status.current) {
+            return;
+        }
+        // The tracking config can outlive the remote-tracking ref (e.g. the
+        // branch was deleted on the remote). Resetting onto a ref that no
+        // longer exists locally would fail, so bail out the same way
+        // getUnpushedCommits() does.
+        const [remote] = splitRemoteBranch(trackingBranch);
+        const remoteBranches = await this.getRemoteBranches(remote);
+        if (!remoteBranches.includes(trackingBranch)) {
             return;
         }
         // A soft reset keeps the index, so any staged but uncommitted changes
@@ -864,13 +873,21 @@ export class SimpleGit extends GitManager {
         if (merges > 0) {
             return;
         }
+        // Capture the current tip before rewriting so the squash commit can
+        // reuse its message (commit -C) rather than the auto-commit template.
+        const oldHead = (await this.git.raw(["rev-parse", "HEAD"])).trim();
         this.plugin.setPluginState({ gitAction: CurrentGitAction.commit });
-        // Soft reset keeps the index and working tree, so all unpushed changes
-        // stay staged and are re-committed as a single commit.
-        await this.git.reset(["--soft", trackingBranch]);
-        await this.git.commit(await this.formatCommitMessage(message));
-        this.app.workspace.trigger("obsidian-git:head-change");
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        try {
+            // Soft reset keeps the index and working tree, so all unpushed
+            // changes stay staged and are re-committed as a single commit.
+            await this.git.reset(["--soft", trackingBranch]);
+            await this.git.raw(["commit", "-C", oldHead]);
+            this.app.workspace.trigger("obsidian-git:head-change");
+        } finally {
+            // Always restore the idle state, even if the reset or commit throws,
+            // so a failed squash never leaves the plugin stuck on "commit".
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
     }
 
     async getUnpushedCommits(): Promise<number> {

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -818,6 +818,50 @@ export class SimpleGit extends GitManager {
         }
     }
 
+    /**
+     * Squashes all local commits that have not been pushed yet into a single
+     * commit. Only unpushed history is rewritten (HEAD is soft-reset onto the
+     * tracking branch), so this never requires a force-push and is safe across
+     * multiple devices. No-op if there is no tracking branch, fewer than two
+     * unpushed commits, or a merge commit is present in the unpushed range.
+     */
+    async squashAllUnpushedCommits({
+        message,
+    }: {
+        message: string;
+    }): Promise<void> {
+        const status = await this.git.status();
+        const trackingBranch = status.tracking;
+        if (!trackingBranch || !status.current) {
+            return;
+        }
+        const range = `${trackingBranch}..HEAD`;
+        const unpushed = parseInt(
+            (await this.git.raw(["rev-list", "--count", range])).trim(),
+            10
+        );
+        if (unpushed < 2) {
+            return;
+        }
+        // Flattening a merge commit would lose its structure, so skip those.
+        const merges = parseInt(
+            (
+                await this.git.raw(["rev-list", "--merges", "--count", range])
+            ).trim(),
+            10
+        );
+        if (merges > 0) {
+            return;
+        }
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.commit });
+        // Soft reset keeps the index and working tree, so all unpushed changes
+        // stay staged and are re-committed as a single commit.
+        await this.git.reset(["--soft", trackingBranch]);
+        await this.git.commit(await this.formatCommitMessage(message));
+        this.app.workspace.trigger("obsidian-git:head-change");
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+    }
+
     async getUnpushedCommits(): Promise<number> {
         const status = await this.git.status();
         const trackingBranch = status.tracking;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1117,9 +1117,7 @@ export default class ObsidianGit extends Plugin {
                 this.settings.squashCommitsBeforePush &&
                 this.gitManager instanceof SimpleGit
             ) {
-                await this.gitManager.squashAllUnpushedCommits({
-                    message: this.settings.autoCommitMessage,
-                });
+                await this.gitManager.squashAllUnpushedCommits();
             }
             this.log("Pushing....");
             const pushedFiles = await this.gitManager.push();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1110,6 +1110,17 @@ export default class ObsidianGit extends Plugin {
                 this.displayError(`Cannot push. You have conflicts`);
                 return false;
             }
+            // Squash local unpushed commits into one before pushing, so frequent
+            // local commits don't clutter the remote history. Only unpushed
+            // history is rewritten (no force-push). Conflicts are excluded above.
+            if (
+                this.settings.squashCommitsBeforePush &&
+                this.gitManager instanceof SimpleGit
+            ) {
+                await this.gitManager.squashAllUnpushedCommits({
+                    message: this.settings.autoCommitMessage,
+                });
+            }
             this.log("Pushing....");
             const pushedFiles = await this.gitManager.push();
 

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -488,6 +488,25 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
 
             if (plugin.gitManager instanceof SimpleGit) {
                 new Setting(containerEl)
+                    .setName("Squash commits before push")
+                    .setDesc(
+                        "On commit-and-sync, squash all local unpushed commits into a single commit right before pushing. Keeps the remote history clean when committing often. Only unpushed commits are rewritten, so no force-push is needed. Desktop only."
+                    )
+                    .addToggle((toggle) =>
+                        toggle
+                            .setValue(
+                                plugin.settings.squashCommitsBeforePush
+                            )
+                            .onChange(async (value) => {
+                                plugin.settings.squashCommitsBeforePush =
+                                    value;
+                                await plugin.saveSettings();
+                            })
+                    );
+            }
+
+            if (plugin.gitManager instanceof SimpleGit) {
+                new Setting(containerEl)
                     .setName("Hunk management")
                     .setDesc(
                         "Hunks are sections of grouped line changes right in your editor."

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -490,7 +490,7 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                 new Setting(containerEl)
                     .setName("Squash commits before push")
                     .setDesc(
-                        "On commit-and-sync, squash all local unpushed commits into a single commit right before pushing. Keeps the remote history clean when committing often. Only unpushed commits are rewritten, so no force-push is needed. Desktop only."
+                        "On commit-and-sync, squash all local unpushed commits into a single commit right before pushing. Keeps the remote history clean when committing often. Only unpushed commits are rewritten, so no force-push is needed."
                     )
                     .addToggle((toggle) =>
                         toggle

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -494,12 +494,9 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                     )
                     .addToggle((toggle) =>
                         toggle
-                            .setValue(
-                                plugin.settings.squashCommitsBeforePush
-                            )
+                            .setValue(plugin.settings.squashCommitsBeforePush)
                             .onChange(async (value) => {
-                                plugin.settings.squashCommitsBeforePush =
-                                    value;
+                                plugin.settings.squashCommitsBeforePush = value;
                                 await plugin.saveSettings();
                             })
                     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,12 @@ export interface ObsidianGitSettings {
      */
     pullBeforePush: boolean;
     /**
+     * Whether to squash all local unpushed commits into a single commit right
+     * before pushing on commit-and-sync. Only rewrites unpushed history, so no
+     * force-push is required. Desktop (SimpleGit) only.
+     */
+    squashCommitsBeforePush: boolean;
+    /**
      * Whether messages from {@link ObsidianGit.displayMessage} should be shown
      */
     disablePopups: boolean;


### PR DESCRIPTION
Adds a "Squash commits before push" toggle (desktop only).

When enabled, all local commits that have not been pushed yet are combined into a single commit right before pushing. This keeps the remote history clean when using a short commit interval. Only unpushed commits are rewritten, so no force push is needed and it is safe across several devices.