### PR TITLE
feat: add option to commit-and-sync before quitting

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_SETTINGS: ObsidianGitSettings = {
     autoCommitOnlyStaged: false,
     disablePush: false,
     pullBeforePush: true,
+    commitAndSyncOnQuit: false,
     disablePopups: false,
     showErrorNotices: true,
     disablePopupsForNoChanges: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -233,6 +233,21 @@ export default class ObsidianGit extends Plugin {
         );
 
         this.registerEvent(
+            this.app.workspace.on("quit", (tasks) => {
+                if (!this.settings.commitAndSyncOnQuit) return;
+                tasks.add(async () => {
+                    // Best effort: don't block quitting if the network hangs.
+                    await Promise.race([
+                        this.commitAndSync({ fromAutoBackup: false }),
+                        new Promise<void>((resolve) =>
+                            window.setTimeout(resolve, 30 * 1000)
+                        ),
+                    ]).catch((e) => this.displayError(e));
+                });
+            })
+        );
+
+        this.registerEvent(
             this.app.workspace.on("file-menu", (menu, file, source) => {
                 this.handleFileMenu(menu, file, source, "file-manu");
             })

--- a/src/setting/settings.ts
+++ b/src/setting/settings.ts
@@ -486,6 +486,20 @@ export class ObsidianGitSettingsTab extends PluginSettingTab {
                         })
                 );
 
+            new Setting(containerEl)
+                .setName("Commit-and-sync before quitting Obsidian")
+                .setDesc(
+                    "Run a commit-and-sync automatically when Obsidian is about to quit, so the last changes are pushed before closing. Best effort: it may not run on a crash or a forced quit."
+                )
+                .addToggle((toggle) =>
+                    toggle
+                        .setValue(plugin.settings.commitAndSyncOnQuit)
+                        .onChange(async (value) => {
+                            plugin.settings.commitAndSyncOnQuit = value;
+                            await plugin.saveSettings();
+                        })
+                );
+
             if (plugin.gitManager instanceof SimpleGit) {
                 new Setting(containerEl)
                     .setName("Hunk management")

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,11 @@ export interface ObsidianGitSettings {
      */
     pullBeforePush: boolean;
     /**
+     * Whether to run a commit-and-sync automatically when Obsidian is about to
+     * quit. Best effort: the quit event is not guaranteed to run.
+     */
+    commitAndSyncOnQuit: boolean;
+    /**
      * Whether messages from {@link ObsidianGit.displayMessage} should be shown
      */
     disablePopups: boolean;


### PR DESCRIPTION
Adds a "Commit-and-sync before quitting Obsidian" toggle.

When enabled, the plugin runs a commit-and-sync on the quit event, so the last local changes are pushed before Obsidian closes. It uses the official quit hook and has a timeout so a hanging network does not block quitting. This is best effort, since the quit event is not guaranteed to run on a crash or a forced quit.