### PR TITLE
fix(auto): prevent immediate sync on startup when last backup time is missing

### DIFF
--- a/src/automaticsManager.ts
+++ b/src/automaticsManager.ts
@@ -261,6 +261,9 @@ export default class AutomaticsManager {
      * This is done by the difference between the setting and the time since the last auto action, but at least 0.
      */
     private diff(setting: number, lastAuto: Date) {
+        if (isNaN(lastAuto.getTime())) {
+            return setting;
+        }
         const now = new Date();
         const diff =
             setting -


### PR DESCRIPTION
On a fresh install or when local storage is cleared, getLastAutoBackup(), getLastAutoPull(), and getLastAutoPush() return null, resulting in Invalid Date from new Date(null ?? "").

This causes the time differences computed by this.diff() to return NaN. Passing NaN to window.setTimeout() resolves to an immediate 0ms/1ms callback. This triggers unwanted and performance-degrading git operations immediately on boot instead of waiting for the configured intervals.

This change fixes the issue by checking for invalid Date states in diff() and returning the setting directly.