### PR TITLE
fix(queue): wrap onFinished in try-catch to prevent deadlock on callback error

### DIFF
--- a/src/promiseQueue.ts
+++ b/src/promiseQueue.ts
@@ -29,13 +29,21 @@ export class PromiseQueue {
             const item = this.tasks[0];
             item.task().then(
                 (res) => {
-                    item.onFinished(res);
+                    try {
+                        item.onFinished(res);
+                    } catch (e) {
+                        console.error(e);
+                    }
                     this.tasks.shift();
                     this.handleTask();
                 },
                 (e) => {
                     this.plugin.displayError(e);
-                    item.onFinished(undefined);
+                    try {
+                        item.onFinished(undefined);
+                    } catch (err) {
+                        console.error(err);
+                    }
                     this.tasks.shift();
                     this.handleTask();
                 }


### PR DESCRIPTION
In PromiseQueue.handleTask(), if a task's onFinished callback throws an error, the exception is unhandled and halts execution of the promise success/error chain. As a result, the queue fails to call this.tasks.shift() or trigger the next handleTask(), permanently deadlocking the git task queue.

This change wraps all onFinished callback calls inside try-catch blocks to ensure queue scheduling behaves reliably even if UI or settings callbacks throw.