### PR TITLE
fix(git): support recursive flag directly in rmdir for isomorphic-git

### DIFF
--- a/src/gitManager/myAdapter.ts
+++ b/src/gitManager/myAdapter.ts
@@ -111,8 +111,10 @@ export class MyAdapter {
         return this.adapter.mkdir(path);
     }
     async rmdir(path: string, opts: any) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        return this.adapter.rmdir(path, opts?.options?.recursive ?? false);
+        return this.adapter.rmdir(
+            path,
+            opts?.recursive === true || opts?.options?.recursive === true
+        );
     }
     async stat(path: string) {
         if (path.endsWith(this.gitDir + "/index")) {


### PR DESCRIPTION
The custom DataAdapter's rmdir method extracted the recursive option via opts?.options?.recursive. However, isomorphic-git passes the options object directly as the second argument (following standard Node.js FS APIs), meaning that the recursive option resides directly on opts?.recursive. This caused directory cleanups during checkouts or clones to fail to delete recursively.

This change fixes options parsing by supporting both opts?.recursive and opts?.options?.recursive.