### PR TITLE
refactor(lineauthor): remove duplicate event unregistration

### DIFF
--- a/src/editor/lineAuthor/lineAuthorIntegration.ts
+++ b/src/editor/lineAuthor/lineAuthorIntegration.ts
@@ -154,7 +154,6 @@ export class LineAuthoringFeature {
         this.plg.app.workspace.offref(this.refreshOnCssChangeEvent!);
         this.plg.app.workspace.offref(this.fileOpenEvent!);
         this.plg.app.workspace.offref(this.workspaceLeafChangeEvent!);
-        this.plg.app.workspace.offref(this.refreshOnCssChangeEvent!);
         this.plg.app.vault.offref(this.fileModificationEvent!);
         this.plg.app.workspace.offref(this.headChangeEvent!);
         this.plg.app.vault.offref(this.fileRenameEvent!);


### PR DESCRIPTION
In destroyEventHandlers(), this.plg.app.workspace.offref(this.refreshOnCssChangeEvent!) was registered twice. This redundant deregistration call is cleaned up to improve code quality and readability.