### PR TITLE
fix: handle file renames as atomic changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,17 @@ on:
     push:
     pull_request:
 jobs:
+    unit-tests:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v6
+              with:
+                  version: latest
+            - name: Install modules
+              run: pnpm install
+            - name: Run unit tests
+              run: pnpm run test
     svelte-check:
         runs-on: ubuntu-latest
         steps:

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
         "dev": "node esbuild.config.mjs dev",
         "build": "node esbuild.config.mjs production",
         "release": "standard-version",
+        "test": "node --test tests/renameTracker.test.mjs",
         "lint": "eslint src",
-        "format": "prettier --check src",
+        "format": "prettier --check src tests",
         "tsc": "tsc --noEmit",
         "svelte": "svelte-check",
-        "all": "pnpm run tsc && pnpm run svelte && pnpm run format && pnpm run lint"
+        "all": "pnpm run test && pnpm run tsc && pnpm run svelte && pnpm run format && pnpm run lint"
     },
     "keywords": [],
     "author": "Vinzent03",

--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -1,6 +1,11 @@
 import { hostname as osHostname } from "os";
-import { type App, moment, Platform } from "obsidian";
+import { type App, moment, Platform, TFile } from "obsidian";
 import type ObsidianGit from "../main";
+import {
+    pathMatchesDirectory,
+    statusMatchesDirectory,
+    type RenameHint,
+} from "../renameTracker";
 import type {
     BranchInfo,
     DiffFile,
@@ -21,6 +26,9 @@ export abstract class GitManager {
 
     abstract status(opts?: { path?: string }): Promise<Status>;
 
+    /** Returns the index paths exactly as Git stores them. */
+    abstract getIndexPaths(): Promise<ReadonlySet<string>>;
+
     abstract commitAll(_: {
         message: string;
         status?: Status;
@@ -37,11 +45,19 @@ export abstract class GitManager {
 
     abstract unstageAll(_: { dir?: string; status?: Status }): Promise<void>;
 
-    abstract stage(filepath: string, relativeToVault: boolean): Promise<void>;
+    abstract stage(
+        filepath: string,
+        relativeToVault: boolean,
+        from?: string
+    ): Promise<void>;
 
-    abstract unstage(filepath: string, relativeToVault: boolean): Promise<void>;
+    abstract unstage(
+        filepath: string,
+        relativeToVault: boolean,
+        from?: string
+    ): Promise<void>;
 
-    abstract discard(filepath: string): Promise<void>;
+    abstract discard(filepath: string, from?: string): Promise<void>;
 
     abstract discardAll(_: { dir?: string; status?: Status }): Promise<void>;
 
@@ -158,6 +174,80 @@ export abstract class GitManager {
             }
         }
         return filePath;
+    }
+
+    protected async reconcileStatus(
+        status: Status,
+        directory?: string
+    ): Promise<Status> {
+        await this.plugin.waitForRenameTracking();
+        const reconciled = await this.plugin.renameTracker.reconcile(status, {
+            pathExists: (path) =>
+                this.app.vault.adapter.exists(
+                    this.getRelativeVaultPath(path),
+                    true
+                ),
+            getIndexPaths: () => this.getIndexPaths(),
+            getVaultPath: (path) => this.getRelativeVaultPath(path),
+        });
+
+        if (directory == undefined) return reconciled;
+        return {
+            all: reconciled.all.filter((file) =>
+                statusMatchesDirectory(file, directory)
+            ),
+            changed: reconciled.changed.filter((file) =>
+                statusMatchesDirectory(file, directory)
+            ),
+            staged: reconciled.staged.filter((file) =>
+                statusMatchesDirectory(file, directory)
+            ),
+            conflicted: reconciled.conflicted.filter((path) =>
+                pathMatchesDirectory(path, directory)
+            ),
+        };
+    }
+
+    protected getRenamePaths(
+        filepath: string,
+        relativeToVault: boolean,
+        from?: string
+    ): RenameHint | undefined {
+        if (from != undefined) {
+            return {
+                from: this.getRelativeRepoPath(from, relativeToVault),
+                to: filepath,
+            };
+        }
+
+        const source = this.plugin.renameTracker.getSource(filepath);
+        if (source != undefined) return { from: source, to: filepath };
+
+        const destination = this.plugin.renameTracker.getDestination(filepath);
+        if (destination != undefined) {
+            return { from: filepath, to: destination };
+        }
+        return undefined;
+    }
+
+    protected renameMatchesDirectory(
+        rename: RenameHint,
+        directory?: string
+    ): boolean {
+        return (
+            pathMatchesDirectory(rename.from, directory) ||
+            pathMatchesDirectory(rename.to, directory)
+        );
+    }
+
+    protected async trashRepoFile(filepath: string): Promise<void> {
+        const vaultPath = this.getRelativeVaultPath(filepath);
+        const file = this.app.vault.getAbstractFileByPath(vaultPath);
+        if (file instanceof TFile) {
+            await this.app.fileManager.trashFile(file);
+        } else if (await this.app.vault.adapter.exists(vaultPath)) {
+            await this.app.vault.adapter.remove(vaultPath);
+        }
     }
 
     unload(): void {}
@@ -281,6 +371,8 @@ export abstract class GitManager {
 
     async formatCommitMessage(template: string): Promise<string> {
         let status: Status | undefined;
+        const formatPath = (file: FileStatusResult) =>
+            file.from != undefined ? `${file.from} -> ${file.path}` : file.path;
         if (template.includes("{{numFiles}}")) {
             status = await this.status();
             const numFiles = status.staged.length;
@@ -303,9 +395,9 @@ export abstract class GitManager {
             if (status.staged.length < 100) {
                 status.staged.forEach((value: FileStatusResult) => {
                     if (value.index in changeset) {
-                        changeset[value.index].push(value.path);
+                        changeset[value.index].push(formatPath(value));
                     } else {
-                        changeset[value.index] = [value.path];
+                        changeset[value.index] = [formatPath(value)];
                     }
                 });
 
@@ -331,7 +423,7 @@ export abstract class GitManager {
             let files = "";
             // If there are more than 100 files, we don't list them all
             if (status2.staged.length < 100) {
-                files = status2.staged.map((e) => e.path).join("\n");
+                files = status2.staged.map(formatPath).join("\n");
             } else {
                 files = "Too many files to list";
             }

--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -22,6 +22,7 @@ import type {
 } from "../types";
 import { CurrentGitAction, type DiffFile } from "../types";
 import { GeneralModal } from "../ui/modals/generalModal";
+import { pathMatchesDirectory, statusMatchesDirectory } from "../renameTracker";
 import { splitRemoteBranch, worthWalking } from "../utils";
 import { GitManager } from "./gitManager";
 import { MyAdapter } from "./myAdapter";
@@ -161,7 +162,10 @@ export class IsomorphicGit extends GitManager {
             const statusOpts = { ...this.getRepo() } as Parameters<
                 typeof git.statusMatrix
             >[0];
-            if (opts?.path != undefined) {
+            if (
+                opts?.path != undefined &&
+                !this.plugin.renameTracker.hasHints
+            ) {
                 statusOpts.filepaths = [`${opts.path}/`];
             }
             const status = (
@@ -183,15 +187,22 @@ export class IsomorphicGit extends GitManager {
                 }
             }
             const conflicted: string[] = [];
-            window.clearTimeout(timeout);
-            notice?.hide();
-            return { all, changed, staged, conflicted };
+            return await this.reconcileStatus(
+                { all, changed, staged, conflicted },
+                opts?.path
+            );
         } catch (error) {
-            window.clearTimeout(timeout);
-            notice?.hide();
             this.plugin.displayError(error);
             throw error;
+        } finally {
+            window.clearTimeout(timeout);
+            notice?.hide();
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
         }
+    }
+
+    async getIndexPaths(): Promise<ReadonlySet<string>> {
+        return new Set(await this.wrapFS(git.listFiles({ ...this.getRepo() })));
     }
 
     async commitAll({
@@ -247,28 +258,78 @@ export class IsomorphicGit extends GitManager {
         }
     }
 
-    async stage(filepath: string, relativeToVault: boolean): Promise<void> {
-        const gitPath = this.getRelativeRepoPath(filepath, relativeToVault);
-        let vaultPath: string;
-        if (relativeToVault) {
-            vaultPath = filepath;
-        } else {
-            vaultPath = this.getRelativeVaultPath(filepath);
-        }
+    private async stagePath(
+        gitPath: string,
+        from?: string,
+        indexPaths?: Set<string>
+    ): Promise<void> {
+        indexPaths ??= new Set(await this.getIndexPaths());
         try {
-            this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-            if (await this.app.vault.adapter.exists(vaultPath)) {
-                await this.wrapFS(
-                    git.add({ ...this.getRepo(), filepath: gitPath })
+            if (from != undefined) {
+                const sourceExists = await this.app.vault.adapter.exists(
+                    this.getRelativeVaultPath(from),
+                    true
                 );
-            } else {
+                if (sourceExists) {
+                    await this.wrapFS(
+                        git.add({
+                            ...this.getRepo(),
+                            filepath: from,
+                            force: true,
+                        })
+                    );
+                    indexPaths.add(from);
+                } else if (indexPaths.has(from)) {
+                    await this.wrapFS(
+                        git.remove({ ...this.getRepo(), filepath: from })
+                    );
+                    indexPaths.delete(from);
+                }
+            }
+
+            const vaultPath = this.getRelativeVaultPath(gitPath);
+            if (await this.app.vault.adapter.exists(vaultPath, true)) {
+                await this.wrapFS(
+                    git.add({
+                        ...this.getRepo(),
+                        filepath: gitPath,
+                        force: from != undefined,
+                    })
+                );
+                indexPaths.add(gitPath);
+            } else if (indexPaths.has(gitPath)) {
                 await this.wrapFS(
                     git.remove({ ...this.getRepo(), filepath: gitPath })
                 );
+                indexPaths.delete(gitPath);
             }
+        } catch (error) {
+            for (const path of [from, gitPath]) {
+                if (path == undefined) continue;
+                await this.wrapFS(
+                    git.resetIndex({ ...this.getRepo(), filepath: path })
+                ).catch(() => {});
+            }
+            throw error;
+        }
+    }
+
+    async stage(
+        filepath: string,
+        relativeToVault: boolean,
+        from?: string
+    ): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        const gitPath = this.getRelativeRepoPath(filepath, relativeToVault);
+        const rename = this.getRenamePaths(gitPath, relativeToVault, from);
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+        try {
+            await this.stagePath(rename?.to ?? gitPath, rename?.from);
         } catch (error) {
             this.plugin.displayError(error);
             throw error;
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
         }
     }
 
@@ -281,52 +342,93 @@ export class IsomorphicGit extends GitManager {
         status?: Status;
         unstagedFiles?: UnstagedFile[];
     }): Promise<void> {
+        await this.plugin.waitForRenameTracking();
         try {
-            if (status) {
-                await Promise.all(
-                    status.changed.map((file) =>
-                        file.workingDir !== "D"
-                            ? this.wrapFS(
-                                  git.add({
-                                      ...this.getRepo(),
-                                      filepath: file.path,
-                                  })
-                              )
-                            : git.remove({
-                                  ...this.getRepo(),
-                                  filepath: file.path,
-                              })
-                    )
-                );
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+            if (status != undefined || this.plugin.renameTracker.hasHints) {
+                const currentStatus =
+                    status ??
+                    (await this.status(
+                        dir != undefined ? { path: dir } : undefined
+                    ));
+                this.plugin.setPluginState({
+                    gitAction: CurrentGitAction.add,
+                });
+                const handledPaths = new Set<string>();
+                const handledRenames = new Set<string>();
+                const indexPaths = new Set(await this.getIndexPaths());
+                const stageRename = async (rename: {
+                    from: string;
+                    to: string;
+                }): Promise<boolean> => {
+                    if (!this.renameMatchesDirectory(rename, dir)) return false;
+                    const key = `${rename.from}\0${rename.to}`;
+                    if (handledRenames.has(key)) return true;
+                    await this.stagePath(rename.to, rename.from, indexPaths);
+                    handledRenames.add(key);
+                    handledPaths.add(rename.from);
+                    handledPaths.add(rename.to);
+                    return true;
+                };
+
+                for (const rename of this.plugin.renameTracker.getHints()) {
+                    await stageRename(rename);
+                }
+                for (const file of currentStatus.changed) {
+                    if (handledPaths.has(file.path)) continue;
+                    const rename = this.getRenamePaths(
+                        file.path,
+                        false,
+                        file.workingDir === "R" ? file.from : undefined
+                    );
+                    if (
+                        (rename == undefined || !(await stageRename(rename))) &&
+                        statusMatchesDirectory(file, dir)
+                    ) {
+                        await this.stagePath(file.path, file.from, indexPaths);
+                    }
+                }
             } else {
                 const filesToStage =
                     unstagedFiles ?? (await this.getUnstagedFiles(dir ?? "."));
-                await Promise.all(
-                    filesToStage.map(({ path, type }) =>
-                        type == "D"
-                            ? git.remove({ ...this.getRepo(), filepath: path })
-                            : this.wrapFS(
-                                  git.add({ ...this.getRepo(), filepath: path })
-                              )
-                    )
-                );
+                const indexPaths = new Set(await this.getIndexPaths());
+                for (const file of filesToStage) {
+                    await this.stagePath(file.path, undefined, indexPaths);
+                }
             }
         } catch (error) {
             this.plugin.displayError(error);
             throw error;
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
         }
     }
 
-    async unstage(filepath: string, relativeToVault: boolean): Promise<void> {
+    private async resetPath(filepath: string, from?: string): Promise<void> {
+        for (const path of [from, filepath]) {
+            if (path == undefined) continue;
+            await this.wrapFS(
+                git.resetIndex({ ...this.getRepo(), filepath: path })
+            );
+        }
+    }
+
+    async unstage(
+        filepath: string,
+        relativeToVault: boolean,
+        from?: string
+    ): Promise<void> {
+        await this.plugin.waitForRenameTracking();
         try {
             this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-            filepath = this.getRelativeRepoPath(filepath, relativeToVault);
-            await this.wrapFS(
-                git.resetIndex({ ...this.getRepo(), filepath: filepath })
-            );
+            const gitPath = this.getRelativeRepoPath(filepath, relativeToVault);
+            const rename = this.getRenamePaths(gitPath, relativeToVault, from);
+            await this.resetPath(rename?.to ?? gitPath, rename?.from);
         } catch (error) {
             this.plugin.displayError(error);
             throw error;
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
         }
     }
 
@@ -337,30 +439,68 @@ export class IsomorphicGit extends GitManager {
         dir?: string;
         status?: Status;
     }): Promise<void> {
+        await this.plugin.waitForRenameTracking();
         try {
-            let staged: string[];
-            if (status) {
-                staged = status.staged.map((file) => file.path);
-            } else {
-                const res = await this.getStagedFiles(dir ?? ".");
-                staged = res.map(({ path }) => path);
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+            const staged =
+                status?.staged ?? (await this.getStagedFiles(dir ?? "."));
+            const handledPaths = new Set<string>();
+            const renames = new Map<string, { from: string; to: string }>();
+            for (const file of staged) {
+                const statusFile =
+                    "index" in file ? (file as FileStatusResult) : undefined;
+                const from =
+                    statusFile?.index === "R" ? statusFile.from : undefined;
+                const rename = this.getRenamePaths(file.path, false, from);
+                if (
+                    rename != undefined &&
+                    this.renameMatchesDirectory(rename, dir)
+                ) {
+                    renames.set(`${rename.from}\0${rename.to}`, rename);
+                    handledPaths.add(rename.from);
+                    handledPaths.add(rename.to);
+                }
             }
-            await this.wrapFS(
-                Promise.all(
-                    staged.map((file) =>
-                        git.resetIndex({ ...this.getRepo(), filepath: file })
-                    )
-                )
-            );
+
+            for (const rename of renames.values()) {
+                await this.resetPath(rename.to, rename.from);
+            }
+            for (const file of staged) {
+                if (
+                    !handledPaths.has(file.path) &&
+                    pathMatchesDirectory(file.path, dir)
+                ) {
+                    await this.resetPath(file.path);
+                }
+            }
         } catch (error) {
             this.plugin.displayError(error);
             throw error;
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
         }
     }
 
-    async discard(filepath: string): Promise<void> {
+    async discard(filepath: string, from?: string): Promise<void> {
+        await this.plugin.waitForRenameTracking();
         try {
             this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+            if (from != undefined) {
+                const isCaseOnlyRename =
+                    from !== filepath &&
+                    from.toLowerCase() === filepath.toLowerCase();
+                if (isCaseOnlyRename) await this.trashRepoFile(filepath);
+                await this.wrapFS(
+                    git.checkout({
+                        ...this.getRepo(),
+                        filepaths: [from],
+                        force: true,
+                    })
+                );
+                if (!isCaseOnlyRename) await this.trashRepoFile(filepath);
+                this.plugin.renameTracker.forgetPath(filepath);
+                return;
+            }
             await this.wrapFS(
                 git.checkout({
                     ...this.getRepo(),
@@ -371,6 +511,8 @@ export class IsomorphicGit extends GitManager {
         } catch (error) {
             this.plugin.displayError(error);
             throw error;
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
         }
     }
 
@@ -381,34 +523,35 @@ export class IsomorphicGit extends GitManager {
         dir?: string;
         status?: Status;
     }): Promise<void> {
-        let files: string[] = [];
-        if (status) {
-            if (dir != undefined) {
-                files = status.changed
-                    .filter(
-                        (file) =>
-                            file.workingDir != "U" && file.path.startsWith(dir)
-                    )
-                    .map((file) => file.path);
-            } else {
-                files = status.changed
-                    .filter((file) => file.workingDir != "U")
-                    .map((file) => file.path);
-            }
-        } else {
-            files = (await this.getUnstagedFiles(dir))
-                .filter((file) => file.type != "A")
-                .map(({ path }) => path);
-        }
+        await this.plugin.waitForRenameTracking();
+        const currentStatus =
+            status ??
+            (await this.status(dir != undefined ? { path: dir } : undefined));
+        const changed = currentStatus.changed.filter((file) =>
+            statusMatchesDirectory(file, dir)
+        );
 
         try {
-            await this.wrapFS(
-                git.checkout({
-                    ...this.getRepo(),
-                    filepaths: files,
-                    force: true,
-                })
-            );
+            for (const file of changed) {
+                if (file.from != undefined && file.workingDir === "R") {
+                    await this.discard(file.path, file.from);
+                }
+            }
+
+            const files = changed
+                .filter(
+                    (file) => file.workingDir !== "U" && file.workingDir !== "R"
+                )
+                .map((file) => file.path);
+            if (files.length > 0) {
+                await this.wrapFS(
+                    git.checkout({
+                        ...this.getRepo(),
+                        filepaths: files,
+                        force: true,
+                    })
+                );
+            }
         } catch (error) {
             this.plugin.displayError(error);
             throw error;

--- a/src/gitManager/simpleGit.ts
+++ b/src/gitManager/simpleGit.ts
@@ -26,6 +26,7 @@ import type {
     Status,
 } from "../types";
 import { CurrentGitAction, NoNetworkError } from "../types";
+import { statusMatchesDirectory } from "../renameTracker";
 import { impossibleBranch, spawnAsync, splitRemoteBranch } from "../utils";
 import { GitManager } from "./gitManager";
 
@@ -350,10 +351,20 @@ export class SimpleGit extends GitManager {
     async status(opts?: { path?: string }): Promise<Status> {
         const dir = opts?.path;
         this.plugin.setPluginState({ gitAction: CurrentGitAction.status });
-        const status = await this.git.status(
-            dir != undefined ? ["--", dir] : []
-        );
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        const args = ["--renames"];
+        if (this.plugin.renameTracker.hasHints) {
+            args.push("--untracked-files=all");
+        }
+        if (dir != undefined && !this.plugin.renameTracker.hasHints) {
+            args.push("--", dir);
+        }
+
+        let status: simple.StatusResult;
+        try {
+            status = await this.git.status(args);
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
 
         const allFilesFormatted = status.files.map<FileStatusResult>((e) => {
             const res = this.formatPath(e);
@@ -365,16 +376,24 @@ export class SimpleGit extends GitManager {
                 vaultPath: this.getRelativeVaultPath(res.path),
             };
         });
-        return {
-            all: allFilesFormatted,
-            changed: allFilesFormatted.filter((e) => e.workingDir !== " "),
-            staged: allFilesFormatted.filter(
-                (e) => e.index !== " " && e.index != "U"
-            ),
-            conflicted: status.conflicted.map(
-                (path) => this.formatPath({ path }).path
-            ),
-        };
+        return this.reconcileStatus(
+            {
+                all: allFilesFormatted,
+                changed: allFilesFormatted.filter((e) => e.workingDir !== " "),
+                staged: allFilesFormatted.filter(
+                    (e) => e.index !== " " && e.index != "U"
+                ),
+                conflicted: status.conflicted.map(
+                    (path) => this.formatPath({ path }).path
+                ),
+            },
+            dir
+        );
+    }
+
+    async getIndexPaths(): Promise<ReadonlySet<string>> {
+        const output = await this.git.raw(["ls-files", "-z"]);
+        return new Set(output.split("\0").filter((path) => path.length > 0));
     }
 
     async submoduleAwareHeadRevisonInContainingDirectory(
@@ -510,7 +529,15 @@ export class SimpleGit extends GitManager {
         return this.git.raw(args).then((x) => x.trim() !== "");
     }
 
-    async commitAll({ message }: { message: string }): Promise<number> {
+    async commitAll({
+        message,
+        status,
+        amend,
+    }: {
+        message: string;
+        status?: Status;
+        amend?: boolean;
+    }): Promise<number> {
         if (this.plugin.settings.updateSubmodules) {
             this.plugin.setPluginState({ gitAction: CurrentGitAction.commit });
             const submodulePaths = await this.getSubmodulePaths();
@@ -521,18 +548,8 @@ export class SimpleGit extends GitManager {
                     .commit(await this.formatCommitMessage(message));
             }
         }
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-
-        await this.git.add("-A");
-
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.commit });
-
-        const res = await this.git.commit(
-            await this.formatCommitMessage(message)
-        );
-        this.app.workspace.trigger("obsidian-git:head-change");
-
-        return res.summary.changes;
+        await this.stageAll({ status });
+        return this.commit({ message, amend });
     }
 
     async commit({
@@ -556,42 +573,203 @@ export class SimpleGit extends GitManager {
         return res;
     }
 
-    async stage(path: string, relativeToVault: boolean): Promise<void> {
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-
-        path = this.getRelativeRepoPath(path, relativeToVault);
-        await this.git.add(["--", path]);
-
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
-    }
-
-    async stageAll({ dir }: { dir?: string }): Promise<void> {
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-        await this.git.add(dir ?? "-A");
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
-    }
-
-    async unstageAll({ dir }: { dir?: string }): Promise<void> {
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-        await this.git.reset(dir != undefined ? ["--", dir] : []);
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
-    }
-
-    async unstage(path: string, relativeToVault: boolean): Promise<void> {
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-
-        path = this.getRelativeRepoPath(path, relativeToVault);
-        await this.git.reset(["--", path]);
-
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
-    }
-
-    async discard(filepath: string): Promise<void> {
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
-        if (await this.isTracked(filepath)) {
-            await this.git.checkout(["--", filepath]);
+    private async stagePath(
+        path: string,
+        from?: string,
+        indexPaths?: Set<string>,
+        ignoreCase?: boolean
+    ): Promise<void> {
+        if (from == undefined) {
+            await this.git.add(["--", path]);
+            return;
         }
-        this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+
+        const isCaseOnlyRename =
+            from !== path && from.toLowerCase() === path.toLowerCase();
+        const sourceStillExists =
+            isCaseOnlyRename &&
+            (await this.app.vault.adapter.exists(
+                this.getRelativeVaultPath(from),
+                true
+            ));
+        const requiresCaseSensitiveIndexUpdate =
+            isCaseOnlyRename &&
+            !sourceStillExists &&
+            (ignoreCase ??
+                (await this.getConfig("core.ignorecase", "all")) === "true");
+        if (!requiresCaseSensitiveIndexUpdate) {
+            await this.git.raw(["add", "-A", "-f", "--", from, path]);
+            return;
+        }
+
+        let removedSource = false;
+        try {
+            indexPaths ??= new Set(await this.getIndexPaths());
+            if (indexPaths.has(from)) {
+                await this.git.raw(["rm", "--cached", "-f", "--", from]);
+                indexPaths.delete(from);
+                removedSource = true;
+            }
+            await this.git.raw(["add", "-A", "-f", "--", path]);
+            indexPaths.add(path);
+        } catch (error) {
+            if (removedSource) {
+                await this.git.reset(["--", from, path]).catch(() => {});
+            }
+            throw error;
+        }
+    }
+
+    async stage(
+        path: string,
+        relativeToVault: boolean,
+        from?: string
+    ): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        const gitPath = this.getRelativeRepoPath(path, relativeToVault);
+        const rename = this.getRenamePaths(gitPath, relativeToVault, from);
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+        try {
+            await this.stagePath(rename?.to ?? gitPath, rename?.from);
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
+    }
+
+    async stageAll({
+        dir,
+        status,
+    }: {
+        dir?: string;
+        status?: Status;
+    }): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        const currentStatus =
+            status ??
+            (this.plugin.renameTracker.hasHints
+                ? await this.status(
+                      dir != undefined ? { path: dir } : undefined
+                  )
+                : undefined);
+        const renames = new Map<string, { from: string; to: string }>();
+        const conflicted = new Set(currentStatus?.conflicted ?? []);
+        const addRename = (rename: { from: string; to: string }) => {
+            if (
+                !conflicted.has(rename.from) &&
+                !conflicted.has(rename.to) &&
+                this.renameMatchesDirectory(rename, dir)
+            ) {
+                renames.set(`${rename.from}\0${rename.to}`, rename);
+            }
+        };
+        this.plugin.renameTracker.getHints().forEach(addRename);
+        for (const file of currentStatus?.all ?? []) {
+            if (
+                file.from != undefined &&
+                (file.index === "R" || file.workingDir === "R")
+            ) {
+                addRename({ from: file.from, to: file.path });
+            }
+        }
+
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+        try {
+            await this.git.add(dir != undefined ? ["-A", "--", dir] : "-A");
+            const hasCaseOnlyRename = [...renames.values()].some(
+                ({ from, to }) =>
+                    from !== to && from.toLowerCase() === to.toLowerCase()
+            );
+            const ignoreCase = hasCaseOnlyRename
+                ? (await this.getConfig("core.ignorecase", "all")) === "true"
+                : undefined;
+            const indexPaths = ignoreCase
+                ? new Set(await this.getIndexPaths())
+                : undefined;
+            for (const rename of renames.values()) {
+                await this.stagePath(
+                    rename.to,
+                    rename.from,
+                    indexPaths,
+                    ignoreCase
+                );
+            }
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
+    }
+
+    async unstageAll({
+        dir,
+        status,
+    }: {
+        dir?: string;
+        status?: Status;
+    }): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        const currentStatus =
+            dir != undefined ? status ?? (await this.status()) : undefined;
+        const renames = new Map<string, { from: string; to: string }>();
+        for (const file of currentStatus?.staged ?? []) {
+            const rename = this.getRenamePaths(
+                file.path,
+                false,
+                file.index === "R" ? file.from : undefined
+            );
+            if (
+                rename != undefined &&
+                this.renameMatchesDirectory(rename, dir)
+            ) {
+                renames.set(`${rename.from}\0${rename.to}`, rename);
+            }
+        }
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+        try {
+            await this.git.reset(dir != undefined ? ["--", dir] : []);
+            for (const rename of renames.values()) {
+                await this.git.reset(["--", rename.from, rename.to]);
+            }
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
+    }
+
+    async unstage(
+        path: string,
+        relativeToVault: boolean,
+        from?: string
+    ): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        const gitPath = this.getRelativeRepoPath(path, relativeToVault);
+        const rename = this.getRenamePaths(gitPath, relativeToVault, from);
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+        try {
+            await this.git.reset([
+                "--",
+                ...(rename != undefined ? [rename.from, rename.to] : [gitPath]),
+            ]);
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
+    }
+
+    async discard(filepath: string, from?: string): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+        try {
+            if (from != undefined) {
+                const isCaseOnlyRename =
+                    from !== filepath &&
+                    from.toLowerCase() === filepath.toLowerCase();
+                if (isCaseOnlyRename) await this.trashRepoFile(filepath);
+                await this.git.checkout(["--", from]);
+                if (!isCaseOnlyRename) await this.trashRepoFile(filepath);
+                this.plugin.renameTracker.forgetPath(filepath);
+            } else if (await this.isTracked(filepath)) {
+                await this.git.checkout(["--", filepath]);
+            }
+        } finally {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.idle });
+        }
     }
 
     async applyPatch(patch: string): Promise<void> {
@@ -637,8 +815,41 @@ export class SimpleGit extends GitManager {
         return revision;
     }
 
-    async discardAll({ dir }: { dir?: string }): Promise<void> {
-        return this.discard(dir ?? ".");
+    async discardAll({
+        dir,
+        status,
+    }: {
+        dir?: string;
+        status?: Status;
+    }): Promise<void> {
+        await this.plugin.waitForRenameTracking();
+        const currentStatus =
+            status ??
+            (await this.status(dir != undefined ? { path: dir } : undefined));
+        const changed = currentStatus.changed.filter((file) =>
+            statusMatchesDirectory(file, dir)
+        );
+        for (const file of changed) {
+            if (file.from != undefined && file.workingDir === "R") {
+                await this.discard(file.path, file.from);
+            }
+        }
+
+        const paths = changed
+            .filter(
+                (file) => file.workingDir !== "U" && file.workingDir !== "R"
+            )
+            .map((file) => file.path);
+        if (paths.length > 0) {
+            this.plugin.setPluginState({ gitAction: CurrentGitAction.add });
+            try {
+                await this.git.checkout(["--", ...paths]);
+            } finally {
+                this.plugin.setPluginState({
+                    gitAction: CurrentGitAction.idle,
+                });
+            }
+        }
     }
 
     async pull(): Promise<FileStatusResult[] | undefined> {
@@ -882,9 +1093,13 @@ export class SimpleGit extends GitManager {
         limit?: number,
         ref?: string
     ): Promise<(LogEntry & { fileName?: string })[]> {
+        await this.plugin.waitForRenameTracking();
         let path: string | undefined;
         if (file) {
             path = this.getRelativeRepoPath(file, relativeToVault);
+            if (ref == undefined) {
+                path = this.plugin.renameTracker.getSource(path) ?? path;
+            }
         }
         const opts: Record<string, unknown> = {
             file: path,
@@ -892,8 +1107,12 @@ export class SimpleGit extends GitManager {
             // Ensures that the changed files are listed for merge commits as well and the commit is not repeated for each parent.
             // This only lists the changed files for the first parent.
             "--diff-merges": "first-parent",
+            "--find-renames": null,
             "--name-status": null,
         };
+        if (path != undefined) {
+            opts["--follow"] = null;
+        }
         if (ref) {
             opts[ref] = null;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import * as path from "path";
 import * as fsPromises from "fs/promises";
 import { pluginRef } from "src/pluginGlobalRef";
 import { PromiseQueue } from "src/promiseQueue";
+import { RenameTracker, type RenameHint } from "src/renameTracker";
 import { ObsidianGitSettingsTab } from "src/setting/settings";
 import { StatusBar } from "src/statusBar";
 import { CustomMessageModal } from "src/ui/modals/customMessageModal";
@@ -69,6 +70,10 @@ export default class ObsidianGit extends Plugin {
     automaticsManager = new AutomaticsManager(this);
     tools = new Tools(this);
     localStorage = new LocalStorageSettings(this);
+    renameTracker = new RenameTracker(
+        this.localStorage.getRenameHints(),
+        (hints) => this.localStorage.setRenameHints(hints)
+    );
     settings: ObsidianGitSettings;
     settingsTab?: ObsidianGitSettingsTab;
     statusBar?: StatusBar;
@@ -80,6 +85,7 @@ export default class ObsidianGit extends Plugin {
     lastPulledFiles: FileStatusResult[];
     gitReady = false;
     promiseQueue: PromiseQueue = new PromiseQueue(this);
+    private renameQueue: Promise<void> = Promise.resolve();
 
     /**
      * Debouncer for the auto commit after file changes.
@@ -268,9 +274,15 @@ export default class ObsidianGit extends Plugin {
             })
         );
         this.registerEvent(
-            this.app.vault.on("rename", () => {
-                this.debRefresh();
-                this.autoCommitDebouncer?.();
+            this.app.vault.on("rename", (file, oldPath) => {
+                const candidates = this.getRenameCandidates(file, oldPath);
+                this.renameQueue = this.renameQueue
+                    .then(() => this.recordRenames(candidates))
+                    .catch((error) => this.displayError(error));
+                void this.renameQueue.then(() => {
+                    this.debRefresh();
+                    this.autoCommitDebouncer?.();
+                });
             })
         );
 
@@ -321,6 +333,94 @@ export default class ObsidianGit extends Plugin {
         this.setRefreshDebouncer();
 
         addCommmands(this);
+    }
+
+    private getRepoPathForRename(vaultPath: string): string | undefined {
+        if (!(this.gitManager instanceof SimpleGit)) {
+            const basePath = normalizePath(this.settings.basePath).replace(
+                /\/$/,
+                ""
+            );
+            const normalizedVaultPath = normalizePath(vaultPath);
+            if (
+                basePath.length > 0 &&
+                normalizedVaultPath !== basePath &&
+                !normalizedVaultPath.startsWith(`${basePath}/`)
+            ) {
+                return undefined;
+            }
+        }
+
+        const repoPath = normalizePath(
+            this.gitManager.getRelativeRepoPath(vaultPath, true)
+        );
+        if (
+            repoPath.length === 0 ||
+            repoPath === "." ||
+            repoPath === ".." ||
+            repoPath.startsWith("../") ||
+            path.isAbsolute(repoPath)
+        ) {
+            return undefined;
+        }
+        return repoPath;
+    }
+
+    private getRenameCandidates(
+        file: TAbstractFile,
+        oldPath: string
+    ): RenameHint[] {
+        if (!this.gitReady) return [];
+
+        const candidates: RenameHint[] = [];
+        const addCandidate = (newVaultPath: string, oldVaultPath: string) => {
+            const from = this.getRepoPathForRename(oldVaultPath);
+            const to = this.getRepoPathForRename(newVaultPath);
+            if (from != undefined && to != undefined && from !== to) {
+                candidates.push({ from, to });
+            }
+        };
+
+        if (file instanceof TFile) {
+            addCandidate(file.path, oldPath);
+        } else if (file instanceof TFolder) {
+            const visit = (folder: TFolder) => {
+                for (const child of folder.children) {
+                    if (child instanceof TFile) {
+                        addCandidate(
+                            child.path,
+                            oldPath + child.path.slice(file.path.length)
+                        );
+                    } else if (child instanceof TFolder) {
+                        visit(child);
+                    }
+                }
+            };
+            visit(file);
+        }
+
+        return candidates;
+    }
+
+    private async recordRenames(candidates: RenameHint[]): Promise<void> {
+        if (candidates.length === 0) return;
+        const indexPaths = await this.gitManager.getIndexPaths();
+        this.renameTracker.recordMany(
+            candidates.filter(({ from }) => {
+                const originalSource = this.renameTracker.getSource(from);
+                // Keep the existing staged rename intact. Its destination is
+                // now an index path, so folding another rename into it would
+                // conflate the index and working-tree destinations.
+                if (originalSource != undefined && indexPaths.has(from)) {
+                    return false;
+                }
+                return indexPaths.has(from) || originalSource != undefined;
+            })
+        );
+    }
+
+    waitForRenameTracking(): Promise<void> {
+        return this.renameQueue;
     }
 
     setRefreshDebouncer(): void {
@@ -905,6 +1005,13 @@ export default class ObsidianGit extends Plugin {
                     const gitManager = this.gitManager as IsomorphicGit;
                     if (onlyStaged) {
                         stagedFiles = await gitManager.getStagedFiles();
+                    } else if (this.renameTracker.hasHints) {
+                        status = await gitManager.status();
+                        stagedFiles = status.staged;
+                        unstagedFiles =
+                            status.changed as unknown as (UnstagedFile & {
+                                vaultPath: string;
+                            })[];
                     } else {
                         const res = await gitManager.getUnstagedFiles();
                         unstagedFiles = res.map(({ path, type }) => ({
@@ -1347,7 +1454,11 @@ export default class ObsidianGit extends Plugin {
     async discardAll(path?: string): Promise<DiscardResult> {
         if (!(await this.isAllInitialized())) return false;
 
-        const status = await this.gitManager.status({ path });
+        const repoPath =
+            path != undefined
+                ? this.gitManager.getRelativeRepoPath(path, true)
+                : undefined;
+        const status = await this.gitManager.status({ path: repoPath });
 
         let filesToDeleteCount = 0;
         let filesToDiscardCount = 0;
@@ -1374,18 +1485,18 @@ export default class ObsidianGit extends Plugin {
                 return result;
             case "discard":
                 await this.gitManager.discardAll({
-                    dir: path,
-                    status: this.cachedStatus,
+                    dir: repoPath,
+                    status,
                 });
                 break;
             case "delete": {
                 await this.gitManager.discardAll({
-                    dir: path,
-                    status: this.cachedStatus,
+                    dir: repoPath,
+                    status,
                 });
                 const untrackedPaths = await this.gitManager.getUntrackedPaths({
-                    path,
-                    status: this.cachedStatus,
+                    path: repoPath,
+                    status,
                 });
                 for (const file of untrackedPaths) {
                     const vaultPath =

--- a/src/renameTracker.ts
+++ b/src/renameTracker.ts
@@ -1,0 +1,333 @@
+import type { FileStatusResult, Status } from "./types";
+
+export interface RenameHint {
+    from: string;
+    to: string;
+}
+
+export interface RenameReconcileContext {
+    pathExists(path: string): Promise<boolean>;
+    getIndexPaths(): Promise<ReadonlySet<string>>;
+    getVaultPath(path: string): string;
+}
+
+function normalizePath(path: string): string {
+    return path.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function isUntracked(file: FileStatusResult): boolean {
+    return file.index === "U" && file.workingDir === "U";
+}
+
+function combineIndexStatus(
+    source: FileStatusResult,
+    destination: FileStatusResult
+): string {
+    if (source.index === "D" && destination.index === "A") return "R";
+    if (destination.index !== " " && destination.index !== "U") {
+        return destination.index;
+    }
+    if (source.index !== " " && source.index !== "U") return source.index;
+    return source.index === "U" ? destination.index : " ";
+}
+
+function combineWorkingTreeStatus(
+    source: FileStatusResult,
+    destination: FileStatusResult
+): string {
+    if (source.workingDir === "D" && isUntracked(destination)) return "R";
+    if (destination.workingDir !== " " && destination.workingDir !== "U") {
+        return destination.workingDir;
+    }
+    if (source.workingDir !== " " && source.workingDir !== "U") {
+        return source.workingDir;
+    }
+    if (destination.workingDir === "U") return "U";
+    return source.workingDir === "U" ? "U" : " ";
+}
+
+/**
+ * Tracks exact rename events reported by Obsidian until Git records them.
+ *
+ * Git stores snapshots rather than rename metadata. Before both paths are
+ * staged, a rename is normally reported as a deletion plus an untracked file.
+ * This class preserves the exact user action so source-control operations can
+ * treat both paths atomically without relying on similarity heuristics.
+ */
+export class RenameTracker {
+    private readonly sourcesByDestination = new Map<string, string>();
+    private readonly destinationsBySource = new Map<string, string>();
+
+    constructor(
+        initialHints: RenameHint[] = [],
+        private readonly saveHints: (hints: RenameHint[]) => void = () => {}
+    ) {
+        for (const hint of initialHints) {
+            if (typeof hint.from === "string" && typeof hint.to === "string") {
+                const from = normalizePath(hint.from);
+                const to = normalizePath(hint.to);
+                if (from !== to) this.setHint(from, to);
+            }
+        }
+    }
+
+    get hasHints(): boolean {
+        return this.sourcesByDestination.size > 0;
+    }
+
+    getSource(destination: string): string | undefined {
+        return this.sourcesByDestination.get(normalizePath(destination));
+    }
+
+    getDestination(source: string): string | undefined {
+        return this.destinationsBySource.get(normalizePath(source));
+    }
+
+    getHints(): RenameHint[] {
+        return [...this.sourcesByDestination].map(([to, from]) => ({
+            from,
+            to,
+        }));
+    }
+
+    record(from: string, to: string): void {
+        this.recordMany([{ from, to }]);
+    }
+
+    recordMany(hints: RenameHint[]): void {
+        let changed = false;
+        for (const hint of hints) {
+            const to = normalizePath(hint.to);
+            let from = normalizePath(hint.from);
+            if (from === to) continue;
+
+            const originalSource = this.sourcesByDestination.get(from);
+            if (originalSource != undefined) {
+                this.deleteHint(from);
+                changed = true;
+                from = originalSource;
+            }
+
+            if (from === to) {
+                changed = this.deleteHint(to) || changed;
+                continue;
+            }
+
+            changed = this.setHint(from, to) || changed;
+        }
+        if (changed) this.persist();
+    }
+
+    forgetPath(path: string): void {
+        path = normalizePath(path);
+        const destination = this.destinationsBySource.get(path);
+        let changed = this.deleteHint(path);
+        if (destination != undefined) {
+            changed = this.deleteHint(destination) || changed;
+        }
+        if (changed) this.persist();
+    }
+
+    async reconcile(
+        status: Status,
+        context: RenameReconcileContext
+    ): Promise<Status> {
+        if (!this.hasHints) return status;
+
+        const files = status.all.map((file) => ({ ...file }));
+        const byPath = new Map(files.map((file) => [file.path, file]));
+        const conflicted = new Set(status.conflicted);
+        const staleHints: string[] = [];
+        let indexPaths: ReadonlySet<string> | undefined;
+
+        const getIndexPaths = async () => {
+            indexPaths ??= await context.getIndexPaths();
+            return indexPaths;
+        };
+
+        for (const [to, from] of this.sourcesByDestination) {
+            if (conflicted.has(from) || conflicted.has(to)) continue;
+            let destination = byPath.get(to);
+            let source = byPath.get(from);
+
+            if (destination?.from != undefined) {
+                const isNativeRename =
+                    destination.index === "R" || destination.workingDir === "R";
+                if (destination.from !== from || !isNativeRename) {
+                    staleHints.push(to);
+                }
+                continue;
+            }
+
+            if (destination == undefined && !(await context.pathExists(to))) {
+                staleHints.push(to);
+                continue;
+            }
+
+            const index = await getIndexPaths();
+            if (destination == undefined && index.has(to)) {
+                staleHints.push(to);
+                continue;
+            }
+            const sourceExists =
+                source == undefined
+                    ? await context.pathExists(from)
+                    : source.workingDir !== "D" &&
+                      !(source.index === "D" && source.workingDir === " ");
+            if (sourceExists && index.has(from)) {
+                staleHints.push(to);
+                continue;
+            }
+            const hasRawChange =
+                source != undefined || destination != undefined;
+            const sourceWasTracked = index.has(from) || source?.index === "D";
+            const isPendingUnstagedRename =
+                !hasRawChange && index.has(from) && !index.has(to);
+
+            if (
+                !sourceWasTracked ||
+                (!hasRawChange && !isPendingUnstagedRename)
+            ) {
+                staleHints.push(to);
+                continue;
+            }
+
+            if (destination == undefined) {
+                destination = {
+                    path: to,
+                    vaultPath: context.getVaultPath(to),
+                    index: "U",
+                    workingDir: "U",
+                };
+                files.push(destination);
+                byPath.set(to, destination);
+            }
+
+            if (source == undefined) {
+                if (sourceExists) continue;
+                const deletionIsStaged =
+                    destination.index === "A" && !index.has(from);
+                source = {
+                    path: from,
+                    vaultPath: context.getVaultPath(from),
+                    index: deletionIsStaged ? "D" : " ",
+                    workingDir: deletionIsStaged ? " " : "D",
+                };
+            }
+
+            const sourceIsInStatus = byPath.has(from);
+            const isUnstagedRename =
+                source.index === " " &&
+                source.workingDir === "D" &&
+                isUntracked(destination);
+            const isStagedRename =
+                source.index === "D" &&
+                source.workingDir === " " &&
+                destination.index === "A";
+
+            // Keep partially staged states split by path. In those states the
+            // index and working tree have different destinations, which a
+            // single FileStatusResult cannot represent faithfully.
+            if (!isUnstagedRename && !isStagedRename) {
+                if (!sourceIsInStatus) {
+                    files.push(source);
+                    byPath.set(from, source);
+                }
+                continue;
+            }
+
+            const combined: FileStatusResult = {
+                ...destination,
+                from,
+                index: combineIndexStatus(source, destination),
+                workingDir: combineWorkingTreeStatus(source, destination),
+            };
+
+            const destinationIndex = files.indexOf(destination);
+            files[destinationIndex] = combined;
+            byPath.set(to, combined);
+
+            const sourceIndex = files.findIndex((file) => file.path === from);
+            if (sourceIndex >= 0) files.splice(sourceIndex, 1);
+            byPath.delete(from);
+        }
+
+        if (staleHints.length > 0) {
+            for (const destination of staleHints) {
+                this.deleteHint(destination);
+            }
+            this.persist();
+        }
+
+        const all = files.filter(
+            (file) => file.index !== " " || file.workingDir !== " "
+        );
+        return {
+            all,
+            changed: all.filter((file) => file.workingDir !== " "),
+            staged: all.filter(
+                (file) => file.index !== " " && file.index !== "U"
+            ),
+            conflicted: status.conflicted,
+        };
+    }
+
+    private persist(): void {
+        this.saveHints(this.getHints());
+    }
+
+    private setHint(from: string, to: string): boolean {
+        if (this.sourcesByDestination.get(to) === from) return false;
+
+        const previousSource = this.sourcesByDestination.get(to);
+        if (previousSource != undefined) {
+            this.destinationsBySource.delete(previousSource);
+        }
+        const previousDestination = this.destinationsBySource.get(from);
+        if (previousDestination != undefined) {
+            this.sourcesByDestination.delete(previousDestination);
+        }
+
+        this.sourcesByDestination.set(to, from);
+        this.destinationsBySource.set(from, to);
+        return true;
+    }
+
+    private deleteHint(destination: string): boolean {
+        const source = this.sourcesByDestination.get(destination);
+        if (source == undefined) return false;
+
+        this.sourcesByDestination.delete(destination);
+        if (this.destinationsBySource.get(source) === destination) {
+            this.destinationsBySource.delete(source);
+        }
+        return true;
+    }
+}
+
+export function statusMatchesDirectory(
+    file: FileStatusResult,
+    directory?: string
+): boolean {
+    if (directory == undefined) return true;
+    directory = normalizePath(directory).replace(/\/+$/, "");
+    if (directory === "" || directory === ".") return true;
+    const prefix = `${directory}/`;
+    return (
+        file.path === directory ||
+        file.path.startsWith(prefix) ||
+        file.from === directory ||
+        file.from?.startsWith(prefix) === true
+    );
+}
+
+export function pathMatchesDirectory(
+    path: string,
+    directory?: string
+): boolean {
+    if (directory == undefined) return true;
+    path = normalizePath(path);
+    directory = normalizePath(directory).replace(/\/+$/, "");
+    if (directory === "" || directory === ".") return true;
+    return path === directory || path.startsWith(`${directory}/`);
+}

--- a/src/setting/localStorageSettings.ts
+++ b/src/setting/localStorageSettings.ts
@@ -1,5 +1,6 @@
 import type { App } from "obsidian";
 import type ObsidianGit from "../main";
+import type { RenameHint } from "../renameTracker";
 export class LocalStorageSettings {
     private prefix: string;
     private app: App;
@@ -171,6 +172,35 @@ export class LocalStorageSettings {
         return this.app.saveLocalStorage(
             this.prefix + "pausedAutomatics",
             `${value}`
+        );
+    }
+
+    getRenameHints(): RenameHint[] {
+        try {
+            const value = this.app.loadLocalStorage(
+                this.prefix + "renameHints"
+            ) as string | null;
+            if (value == null) return [];
+
+            const hints = JSON.parse(value) as unknown;
+            if (!Array.isArray(hints)) return [];
+            return hints.filter((hint): hint is RenameHint => {
+                if (typeof hint !== "object" || hint == null) return false;
+                const candidate = hint as Record<string, unknown>;
+                return (
+                    typeof candidate.from === "string" &&
+                    typeof candidate.to === "string"
+                );
+            });
+        } catch {
+            return [];
+        }
+    }
+
+    setRenameHints(value: RenameHint[]): void {
+        return this.app.saveLocalStorage(
+            this.prefix + "renameHints",
+            JSON.stringify(value)
         );
     }
 

--- a/src/ui/sourceControl/components/fileComponent.svelte
+++ b/src/ui/sourceControl/components/fileComponent.svelte
@@ -21,6 +21,11 @@
 
     let { change, view, manager }: Props = $props();
     let buttons: HTMLElement[] = $state([]);
+    let displayPath = $derived(
+        change.from != undefined && change.workingDir === "R"
+            ? `${manager.getRelativeVaultPath(change.from)} → ${change.vaultPath}`
+            : getDisplayPath(change.vaultPath)
+    );
 
     let side = $derived(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
@@ -61,7 +66,11 @@
     function stage(event: MouseEvent) {
         event.stopPropagation();
         manager
-            .stage(change.path, false)
+            .stage(
+                change.path,
+                false,
+                change.workingDir === "R" ? change.from : undefined
+            )
             .catch((e) => view.plugin.displayError(e))
             .finally(() => {
                 view.app.workspace.trigger("obsidian-git:refresh");
@@ -70,11 +79,20 @@
 
     function showDiff(event: MouseEvent) {
         event.stopPropagation();
-        view.plugin.tools.openDiff({
-            aFile: change.path,
-            aRef: "",
-            event,
-        });
+        if (change.from != undefined && change.workingDir === "R") {
+            view.plugin.tools.openDiff({
+                aFile: change.from,
+                bFile: change.path,
+                aRef: "",
+                event,
+            });
+        } else {
+            view.plugin.tools.openDiff({
+                aFile: change.path,
+                aRef: "",
+                event,
+            });
+        }
     }
 
     function discard(event: MouseEvent) {
@@ -101,9 +119,18 @@
                             );
                         }
                     } else if (result == "discard") {
-                        await manager.discard(change.path).finally(() => {
-                            view.app.workspace.trigger("obsidian-git:refresh");
-                        });
+                        await manager
+                            .discard(
+                                change.path,
+                                change.workingDir === "R"
+                                    ? change.from
+                                    : undefined
+                            )
+                            .finally(() => {
+                                view.app.workspace.trigger(
+                                    "obsidian-git:refresh"
+                                );
+                            });
                     }
 
                     view.app.workspace.trigger("obsidian-git:refresh");
@@ -140,7 +167,7 @@
         class="tree-item-self is-clickable nav-file-title"
         data-path={change.vaultPath}
         data-tooltip-position={side}
-        aria-label={change.vaultPath}
+        aria-label={displayPath}
     >
         <!-- <div
 			data-icon="folder"
@@ -148,7 +175,7 @@
 			style="padding-right: 5px; display: flex;"
 		/> -->
         <div class="tree-item-inner nav-file-title-content">
-            {getDisplayPath(change.vaultPath)}
+            {displayPath}
         </div>
         <div class="git-tools">
             <div class="buttons">

--- a/src/ui/sourceControl/components/stagedFileComponent.svelte
+++ b/src/ui/sourceControl/components/stagedFileComponent.svelte
@@ -20,6 +20,11 @@
 
     let { change, view, manager }: Props = $props();
     let buttons: HTMLElement[] = $state([]);
+    let displayPath = $derived(
+        change.from != undefined
+            ? `${manager.getRelativeVaultPath(change.from)} → ${change.vaultPath}`
+            : getDisplayPath(change.vaultPath)
+    );
     let side = $derived(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
         (view.leaf.getRoot() as any).side == "left" ? "right" : "left"
@@ -70,7 +75,11 @@
         event.stopPropagation();
 
         manager
-            .unstage(change.path, false)
+            .unstage(
+                change.path,
+                false,
+                change.index === "R" ? change.from : undefined
+            )
             .catch((e) => view.plugin.displayError(e))
             .finally(() => {
                 view.app.workspace.trigger("obsidian-git:refresh");
@@ -103,10 +112,10 @@
         class="tree-item-self is-clickable nav-file-title"
         data-path={change.vaultPath}
         data-tooltip-position={side}
-        aria-label={change.vaultPath}
+        aria-label={displayPath}
     >
         <div class="tree-item-inner nav-file-title-content">
-            {getDisplayPath(change.vaultPath)}
+            {displayPath}
         </div>
         <div class="git-tools">
             <div class="buttons">

--- a/tests/renameTracker.test.mjs
+++ b/tests/renameTracker.test.mjs
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { build } from "esbuild";
+
+const bundle = await build({
+    entryPoints: ["src/renameTracker.ts"],
+    bundle: true,
+    format: "esm",
+    logLevel: "silent",
+    platform: "node",
+    write: false,
+});
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(
+    bundle.outputFiles[0].text
+).toString("base64")}`;
+const { RenameTracker, statusMatchesDirectory } = await import(moduleUrl);
+
+const emptyStatus = () => ({
+    all: [],
+    changed: [],
+    staged: [],
+    conflicted: [],
+});
+
+const file = (path, index, workingDir) => ({
+    path,
+    vaultPath: `vault/${path}`,
+    index,
+    workingDir,
+});
+
+const status = (...files) => ({
+    all: files,
+    changed: files.filter((entry) => entry.workingDir !== " "),
+    staged: files.filter((entry) => entry.index !== " " && entry.index !== "U"),
+    conflicted: [],
+});
+
+const context = ({ tracked = ["old.md"], existing = ["new.md"] } = {}) => ({
+    pathExists: (path) => Promise.resolve(existing.includes(path)),
+    getIndexPaths: () => Promise.resolve(new Set(tracked)),
+    getVaultPath: (path) => `vault/${path}`,
+});
+
+test("coalesces rename chains and removes a rename that returns to its source", () => {
+    const saved = [];
+    const tracker = new RenameTracker([], (hints) => saved.push(hints));
+
+    tracker.record("old.md", "middle.md");
+    tracker.record("middle.md", "new.md");
+    assert.deepEqual(tracker.getHints(), [{ from: "old.md", to: "new.md" }]);
+    assert.equal(tracker.getDestination("old.md"), "new.md");
+
+    tracker.record("new.md", "old.md");
+    assert.deepEqual(tracker.getHints(), []);
+    assert.deepEqual(saved[saved.length - 1], []);
+});
+
+test("reconciles an unstaged delete and untracked add as one rename", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const result = await tracker.reconcile(
+        status(file("old.md", " ", "D"), file("new.md", "U", "U")),
+        context()
+    );
+
+    assert.deepEqual(result.all, [
+        {
+            path: "new.md",
+            vaultPath: "vault/new.md",
+            from: "old.md",
+            index: " ",
+            workingDir: "R",
+        },
+    ]);
+    assert.deepEqual(result.changed, result.all);
+    assert.deepEqual(result.staged, []);
+});
+
+test("reconciles staged delete and add entries as one staged rename", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const result = await tracker.reconcile(
+        status(file("old.md", "D", " "), file("new.md", "A", " ")),
+        context({ tracked: ["new.md"] })
+    );
+
+    assert.equal(result.all.length, 1);
+    assert.deepEqual(result.all[0], {
+        path: "new.md",
+        vaultPath: "vault/new.md",
+        from: "old.md",
+        index: "R",
+        workingDir: " ",
+    });
+    assert.deepEqual(result.changed, []);
+    assert.deepEqual(result.staged, result.all);
+});
+
+test("keeps a partially staged rename split by index path", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const originalStatus = status(
+        file("old.md", " ", "D"),
+        file("new.md", "A", " ")
+    );
+    const result = await tracker.reconcile(
+        originalStatus,
+        context({ tracked: ["old.md", "new.md"] })
+    );
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), [{ from: "old.md", to: "new.md" }]);
+});
+
+test("keeps staged source edits separate from an unstaged rename", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const originalStatus = status(
+        file("old.md", "M", "D"),
+        file("new.md", "U", "U")
+    );
+    const result = await tracker.reconcile(originalStatus, context());
+
+    assert.deepEqual(result, originalStatus);
+});
+
+test("keeps a staged rename when its destination is deleted", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const result = await tracker.reconcile(
+        status(file("old.md", "D", " "), file("new.md", "A", "D")),
+        context({ tracked: ["new.md"], existing: [] })
+    );
+
+    assert.deepEqual(result.all[0], {
+        path: "new.md",
+        vaultPath: "vault/new.md",
+        from: "old.md",
+        index: "R",
+        workingDir: "D",
+    });
+});
+
+test("synthesizes a case-only rename hidden by an ignore-case index", async () => {
+    const tracker = new RenameTracker([{ from: "note.md", to: "Note.md" }]);
+    const result = await tracker.reconcile(
+        emptyStatus(),
+        context({ tracked: ["note.md"], existing: ["Note.md"] })
+    );
+
+    assert.deepEqual(result.all[0], {
+        path: "Note.md",
+        vaultPath: "vault/Note.md",
+        from: "note.md",
+        index: " ",
+        workingDir: "R",
+    });
+});
+
+test("reconstructs a rename when the destination is ignored", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const result = await tracker.reconcile(
+        status(file("old.md", " ", "D")),
+        context()
+    );
+
+    assert.deepEqual(result.all[0], {
+        path: "new.md",
+        vaultPath: "vault/new.md",
+        from: "old.md",
+        index: " ",
+        workingDir: "R",
+    });
+});
+
+test("drops stale and untracked rename hints", async () => {
+    const saved = [];
+    const tracker = new RenameTracker(
+        [{ from: "old.md", to: "new.md" }],
+        (hints) => saved.push(hints)
+    );
+    const result = await tracker.reconcile(
+        status(file("new.md", "U", "U")),
+        context({ tracked: [], existing: ["new.md"] })
+    );
+
+    assert.deepEqual(result.all, [file("new.md", "U", "U")]);
+    assert.deepEqual(tracker.getHints(), []);
+    assert.deepEqual(saved[saved.length - 1], []);
+});
+
+test("does not treat a native copy as a rename", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const copied = {
+        ...file("new.md", "C", " "),
+        from: "old.md",
+    };
+    const originalStatus = status(copied);
+    const result = await tracker.reconcile(originalStatus, context());
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), []);
+});
+
+test("preserves a native rename reported by Git", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const renamed = {
+        ...file("new.md", "R", "M"),
+        from: "old.md",
+    };
+    const originalStatus = status(renamed);
+    const result = await tracker.reconcile(originalStatus, context());
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), [{ from: "old.md", to: "new.md" }]);
+});
+
+test("retains the pair when a newly staged file is renamed", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const originalStatus = status(
+        file("old.md", "A", "D"),
+        file("new.md", "U", "U")
+    );
+    const result = await tracker.reconcile(
+        originalStatus,
+        context({ tracked: ["old.md"] })
+    );
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), [{ from: "old.md", to: "new.md" }]);
+});
+
+test("drops a hint when the source reappears before staging", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const originalStatus = status(file("new.md", "U", "U"));
+    const result = await tracker.reconcile(
+        originalStatus,
+        context({ existing: ["old.md", "new.md"] })
+    );
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), []);
+});
+
+test("keeps a staged rename split when the source is recreated", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const originalStatus = status(
+        file("old.md", "D", "A"),
+        file("new.md", "A", " ")
+    );
+    const result = await tracker.reconcile(
+        originalStatus,
+        context({ tracked: ["new.md"], existing: ["old.md", "new.md"] })
+    );
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), [{ from: "old.md", to: "new.md" }]);
+});
+
+test("drops a hint after only the destination was committed", async () => {
+    const tracker = new RenameTracker([{ from: "old.md", to: "new.md" }]);
+    const originalStatus = status(file("old.md", " ", "D"));
+    const result = await tracker.reconcile(
+        originalStatus,
+        context({ tracked: ["old.md", "new.md"] })
+    );
+
+    assert.deepEqual(result, originalStatus);
+    assert.deepEqual(tracker.getHints(), []);
+});
+
+test("matches either endpoint of a cross-directory rename", () => {
+    const renamed = {
+        ...file("destination/note.md", "R", " "),
+        from: "source/note.md",
+    };
+
+    assert.equal(statusMatchesDirectory(renamed, "source"), true);
+    assert.equal(statusMatchesDirectory(renamed, "destination"), true);
+    assert.equal(statusMatchesDirectory(renamed, "other"), false);
+    assert.equal(statusMatchesDirectory(renamed, "./"), true);
+});


### PR DESCRIPTION
## Problem

When a file is renamed in Obsidian, the plugin handles the two paths (deletion + untracked file) independently. Staging only the new path and committing leaves the old file's deletion behind, so the file ends up duplicated. Case-only renames can also be missed when `core.ignorecase=true`.

Related: #62, #579.

## Changes

- Record Obsidian's rename events to pair old and new paths. Nothing is staged automatically.
- Staging, unstaging, or discarding either path applies to both, so a rename lands in the index atomically (`R`).
- Source control shows the pair as `old → new`; file history uses `--follow`.
- Same behavior on desktop and mobile; covers cross-directory, case-only, and folder renames, and ignored destinations.
- Partially staged states stay as separate lines to reflect the real index state. Copies and renames made outside Obsidian behave as before.

Pairings are kept in local storage; chained renames collapse (`A → B → C` becomes `A → C`) and stale entries are dropped after commit, revert, or discard.

## Validation

- `pnpm run all` and `pnpm run build` pass
- 16 dependency-free unit tests, added to CI
- Manually tested normal, case-only, newly-staged, and ignored-destination renames

Note: CI fails in `pnpm/action-setup` before any repo command runs; other recent PRs hit the same failure, so it appears unrelated to this branch.
