### PR TITLE
fix(utils): assign correct stderr variable in spawnAsync error handler

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -304,7 +304,7 @@ export function spawnAsync(
             resolve({
                 error: new Error(err.message),
                 stdout: stdoutBuffer,
-                stderr: stdoutBuffer,
+                stderr: stderrBuffer,
                 code: 1,
             });
         });


### PR DESCRIPTION
it should go to stderr instead of stdout