### PR TITLE
fix(automatics): prevent rescheduling auto runs when plugin is unload…

### DIFF
--- a/src/automaticsManager.ts
+++ b/src/automaticsManager.ts
@@ -120,7 +120,17 @@ export default class AutomaticsManager {
         }
     }
 
+    private get isAutomaticsDisabled(): boolean {
+        return (
+            !this.plugin.gitReady ||
+            this.plugin.localStorage.getPausedAutomatics()
+        );
+    }
+
     private startAutoCommitAndSync(minutes?: number) {
+        if (this.isAutomaticsDisabled) {
+            return;
+        }
         let time = (minutes ?? this.plugin.settings.autoSaveInterval) * 60000;
         if (this.plugin.settings.autoBackupAfterFileChange) {
             if (minutes === 0) {
@@ -187,6 +197,9 @@ export default class AutomaticsManager {
     }
 
     private startAutoPull(minutes?: number) {
+        if (this.isAutomaticsDisabled) {
+            return;
+        }
         let time = (minutes ?? this.plugin.settings.autoPullInterval) * 60000;
         // max timeout in js
         if (time > 2147483647) time = 2147483647;
@@ -205,6 +218,9 @@ export default class AutomaticsManager {
     }
 
     private startAutoPush(minutes?: number) {
+        if (this.isAutomaticsDisabled) {
+            return;
+        }
         let time = (minutes ?? this.plugin.settings.autoPushInterval) * 60000;
         // max timeout in js
         if (time > 2147483647) time = 2147483647;


### PR DESCRIPTION
In Obsidian, plugins can be disabled or updated dynamically. When that happens, Obsidian unloads the plugin, and obsidian-git sets gitReady = false and clears its current timers.

However, if an automatic sync (commit, pull, or push) was already executing when the plugin was unloaded, the running promise couldn't be cancelled. When the Git command finished, its completion callback would run and call the scheduling function (startAutoCommitAndSync, startAutoPull, or startAutoPush) to schedule the next run.

Because the scheduling functions didn't check if the plugin was still loaded, they would register a new window.setTimeout on the global window. When that timer fired, it would run the Git operations and register another timer, indefinitely looping in the background on an unloaded plugin.

