### PR TITLE
fix(promiseQueue): prevent race conditions on clear and handle sync errors

### DIFF
--- a/src/promiseQueue.ts
+++ b/src/promiseQueue.ts
@@ -5,6 +5,7 @@ export class PromiseQueue {
         task: () => Promise<unknown>;
         onFinished: (res: unknown) => void;
     }[] = [];
+    private currentTask: Promise<unknown> | null = null;
 
     constructor(private readonly plugin: ObsidianGit) {}
 
@@ -18,24 +19,34 @@ export class PromiseQueue {
         task: () => Promise<T>,
         onFinished?: (res: T | undefined) => void
     ): void {
-        this.tasks.push({ task, onFinished: onFinished ?? (() => {}) });
-        if (this.tasks.length === 1) {
-            this.handleTask();
-        }
+        this.tasks.push({
+            task,
+            onFinished: (res: unknown) => {
+                if (onFinished) {
+                    onFinished(res as T | undefined);
+                }
+            },
+        });
+        this.kickstart();
     }
 
-    private handleTask(): void {
-        if (this.tasks.length > 0) {
-            const item = this.tasks[0];
-            item.task().then(
+    private kickstart(): void {
+        if (this.currentTask !== null) {
+            return;
+        }
+        if (this.tasks.length === 0) {
+            return;
+        }
+        const item = this.tasks.shift()!;
+        this.currentTask = Promise.resolve()
+            .then(() => item.task())
+            .then(
                 (res) => {
                     try {
                         item.onFinished(res);
                     } catch (e) {
                         console.error(e);
                     }
-                    this.tasks.shift();
-                    this.handleTask();
                 },
                 (e) => {
                     this.plugin.displayError(e);
@@ -44,11 +55,12 @@ export class PromiseQueue {
                     } catch (err) {
                         console.error(err);
                     }
-                    this.tasks.shift();
-                    this.handleTask();
                 }
-            );
-        }
+            )
+            .finally(() => {
+                this.currentTask = null;
+                this.kickstart();
+            });
     }
 
     clear(): void {


### PR DESCRIPTION
### Permanent Queue Deadlock on Synchronous Errors

Previously, calling item.task() directly meant that any synchronous exception thrown by the task (before returning a Promise) would crash the call stack before registering the .then() handlers. As a result, this.tasks.shift() was never reached, leaving the failing task permanently at index 0. The queue would lock up completely, forcing the user to reload the
  plugin.

Wrapped item.task() inside a Promise.resolve().then(...) block. Synchronous exceptions are now safely coerced into promise rejections, allowing the queue to report the error and cleanly proceed to the next item.

  ### Concurrency & Index Corruption on clear()

Previously, a running task remained at this.tasks[0] until it completed. If the queue was cleared (this.tasks = []) and a new task taskB was added while the original was still running, taskB would start immediately—resulting in concurrent execution. When the original task finished, its asynchronous callback would call this.tasks.shift(), which incorrectly
  evicted taskB from the queue and started the next task too early.

Changed the queue's lifecycle from recursive post-execution shifting to synchronous pre-execution shifting tracked by an active currentTask promise reference. Tasks are now shifted off the queue array immediately as they are picked up, separating the execution state from the queue array itself.

### Key Changes

 Introduced currentTask: Promise<unknown> | null to explicitly track the active task state.
 Replaced handleTask with kickstart(), which:
      1. Aborts early if a task is already executing (currentTask !== null).
      2. Shifts the task off the array synchronously.
      3. Chains resolving callbacks, error reporting, and a .finally() block to reset currentTask and kickstart the next task.
 Wrapped the task callback in Promise.resolve().then(() => item.task()) to catch synchronous throws.
