### PR TITLE
fix(events): clean up EventsPerFilePath interval timer on plugin unload

### DIFF
--- a/src/editor/editorIntegration.ts
+++ b/src/editor/editorIntegration.ts
@@ -2,6 +2,7 @@ import type ObsidianGit from "src/main";
 import { LineAuthoringFeature } from "./lineAuthor/lineAuthorIntegration";
 import { SignsFeature } from "./signs/signsIntegration";
 import { subscribeNewEditor } from "./control";
+import { eventsPerFilePathSingleton } from "./eventsPerFilepath";
 
 export class EditorIntegration {
     constructor(private plg: ObsidianGit) {}
@@ -14,9 +15,11 @@ export class EditorIntegration {
     onUnloadPlugin() {
         this.lineAuthoringFeature.deactivateFeature();
         this.signsFeature.deactivateFeature();
+        eventsPerFilePathSingleton.clear();
     }
 
     onLoadPlugin() {
+        eventsPerFilePathSingleton.init();
         this.plg.registerEditorExtension(subscribeNewEditor);
         this.lineAuthoringFeature.onLoadPlugin();
         this.signsFeature.onLoadPlugin();

--- a/src/editor/eventsPerFilepath.ts
+++ b/src/editor/eventsPerFilepath.ts
@@ -11,10 +11,10 @@ const REMOVE_STALES_FREQUENCY = 60 * SECONDS;
  */
 class EventsPerFilePath {
     private eventsPerFilepath: Map<string, FileSubscribers> = new Map();
-    private removeStalesSubscribersTimer: number;
+    private removeStalesSubscribersTimer: number | undefined;
 
     constructor() {
-        this.startRemoveStalesSubscribersInterval();
+        this.init();
     }
 
     /**
@@ -40,6 +40,12 @@ class EventsPerFilePath {
             this.eventsPerFilepath.set(filepath, new Set());
     }
 
+    public init() {
+        if (this.removeStalesSubscribersTimer === undefined) {
+            this.startRemoveStalesSubscribersInterval();
+        }
+    }
+
     private startRemoveStalesSubscribersInterval() {
         this.removeStalesSubscribersTimer = window.setInterval(
             () => this?.forEachSubscriber((las) => las?.removeIfStale()),
@@ -48,7 +54,10 @@ class EventsPerFilePath {
     }
 
     public clear() {
-        window.clearInterval(this.removeStalesSubscribersTimer);
+        if (this.removeStalesSubscribersTimer !== undefined) {
+            window.clearInterval(this.removeStalesSubscribersTimer);
+            this.removeStalesSubscribersTimer = undefined;
+        }
         this.eventsPerFilepath.clear();
     }
 }


### PR DESCRIPTION
# Description
This PR resolves a persistent memory/timer leak in the editor integration events subsystem by binding the lifecycle of the stale subscriber cleanup interval directly to the plugin's load and unload processes.

---

## The Bug: Background Timer Leak
The `EventsPerFilePath` class manages pub-sub editor subscriptions per filepath and runs a background sweeper interval (`setInterval` running every 60 seconds) to detect and remove stale editor subscribers.

Because the class is instantiated as a module-level global singleton (`eventsPerFilePathSingleton`), the interval was registered on the global `window` object immediately during module loading. However, when the plugin was unloaded (e.g. disabled or updated by the user), the interval was never cleared.

This resulted in:
1. The sweeper timer continuing to execute in the background indefinitely.
2. A memory leak, as the global timer retained references to the singleton instance and all internal subscription maps, preventing them from being garbage collected.

---

## The Fix
1. **Lifecycle Management**: Refactored `EventsPerFilePath` to make the sweeper interval start and stop on-demand.
   - Introduced an `init()` method to start the interval if it is not already running.
   - Updated `clear()` to clear the interval via `window.clearInterval()` and nullify the reference, in addition to clearing the internal filepath maps.
2. **Integration Hook**: Hooked the singleton lifecycle directly into the main plugin integration:
   - Called `eventsPerFilePathSingleton.init()` inside `EditorIntegration.onLoadPlugin()`.
   - Called `eventsPerFilePathSingleton.clear()` inside `EditorIntegration.onUnloadPlugin()`.

This ensures that whenever the plugin is disabled or reloaded, the background timer is cleanly stopped and resources are fully freed.

---

## Verification
* Verified that compiler checks (`npm run tsc`) pass cleanly.
* Verified that formatting and linter checks (`npm run lint`) pass with no warnings.
