### PR TITLE
fix(editor): safeguard event unregistrations against undefined values

### DIFF
--- a/src/editor/lineAuthor/lineAuthorIntegration.ts
+++ b/src/editor/lineAuthor/lineAuthorIntegration.ts
@@ -150,13 +150,34 @@ export class LineAuthoringFeature {
     }
 
     private destroyEventHandlers() {
-        this.plg.app.workspace.offref(this.gutterContextMenuEvent!);
-        this.plg.app.workspace.offref(this.refreshOnCssChangeEvent!);
-        this.plg.app.workspace.offref(this.fileOpenEvent!);
-        this.plg.app.workspace.offref(this.workspaceLeafChangeEvent!);
-        this.plg.app.vault.offref(this.fileModificationEvent!);
-        this.plg.app.workspace.offref(this.headChangeEvent!);
-        this.plg.app.vault.offref(this.fileRenameEvent!);
+        if (this.gutterContextMenuEvent) {
+            this.plg.app.workspace.offref(this.gutterContextMenuEvent);
+            this.gutterContextMenuEvent = undefined;
+        }
+        if (this.refreshOnCssChangeEvent) {
+            this.plg.app.workspace.offref(this.refreshOnCssChangeEvent);
+            this.refreshOnCssChangeEvent = undefined;
+        }
+        if (this.fileOpenEvent) {
+            this.plg.app.workspace.offref(this.fileOpenEvent);
+            this.fileOpenEvent = undefined;
+        }
+        if (this.workspaceLeafChangeEvent) {
+            this.plg.app.workspace.offref(this.workspaceLeafChangeEvent);
+            this.workspaceLeafChangeEvent = undefined;
+        }
+        if (this.fileModificationEvent) {
+            this.plg.app.vault.offref(this.fileModificationEvent);
+            this.fileModificationEvent = undefined;
+        }
+        if (this.headChangeEvent) {
+            this.plg.app.workspace.offref(this.headChangeEvent);
+            this.headChangeEvent = undefined;
+        }
+        if (this.fileRenameEvent) {
+            this.plg.app.vault.offref(this.fileRenameEvent);
+            this.fileRenameEvent = undefined;
+        }
     }
 
     private handleWorkspaceLeaf = (leaf: WorkspaceLeaf) => {

--- a/src/editor/signs/signsIntegration.ts
+++ b/src/editor/signs/signsIntegration.ts
@@ -22,7 +22,6 @@ export class SignsFeature {
     private fileRenameEvent?: EventRef;
     private intervalRefreshEvent?: number;
     private pluginRefreshedEvent?: EventRef;
-    private gutterContextMenuEvent?: EventRef;
     private codeMirrorExtensions: Extension[] = [];
     public changeStatusBar?: ChangesStatusBar;
 
@@ -143,11 +142,22 @@ export class SignsFeature {
     }
 
     private destroyEventHandlers() {
-        this.plg.app.workspace.offref(this.workspaceLeafChangeEvent!);
-        this.plg.app.vault.offref(this.fileRenameEvent!);
-        this.plg.app.workspace.offref(this.pluginRefreshedEvent!);
-        this.plg.app.workspace.offref(this.gutterContextMenuEvent!);
-        window.clearInterval(this.intervalRefreshEvent);
+        if (this.workspaceLeafChangeEvent) {
+            this.plg.app.workspace.offref(this.workspaceLeafChangeEvent);
+            this.workspaceLeafChangeEvent = undefined;
+        }
+        if (this.fileRenameEvent) {
+            this.plg.app.vault.offref(this.fileRenameEvent);
+            this.fileRenameEvent = undefined;
+        }
+        if (this.pluginRefreshedEvent) {
+            this.plg.app.workspace.offref(this.pluginRefreshedEvent);
+            this.pluginRefreshedEvent = undefined;
+        }
+        if (this.intervalRefreshEvent !== undefined) {
+            window.clearInterval(this.intervalRefreshEvent);
+            this.intervalRefreshEvent = undefined;
+        }
     }
 
     private handleWorkspaceLeaf = (leaf: WorkspaceLeaf) => {


### PR DESCRIPTION
# Description
This PR safeguards the event handler unregistrations in the editor features (`SignsFeature` and `LineAuthoringFeature`) against `undefined` values during feature deactivation / plugin unloading, and removes a dead field.

---

## The Issue
When features are deactivated (or when the plugin is unloaded), `EditorIntegration` calls `deactivateFeature()` on each feature. If a feature was never activated (for example, if the feature is disabled in settings), its event variables (e.g. `workspaceLeafChangeEvent`, `fileRenameEvent`, `fileOpenEvent`, etc.) remain `undefined`.

Calling `this.plg.app.workspace.offref(this.workspaceLeafChangeEvent!)` directly with `undefined` on deactivation is unsafe. 

Additionally:
- `SignsFeature` declared and unregistered `gutterContextMenuEvent`, but it was never registered or used.

---

## The Fix
1. **Safety Checks**: Updated `destroyEventHandlers()` in both features to verify that event references exist before calling `offref()` on them:
   ```typescript
   if (this.workspaceLeafChangeEvent) {
       this.plg.app.workspace.offref(this.workspaceLeafChangeEvent);
       this.workspaceLeafChangeEvent = undefined;
   }
   ```
2. **Dead Code Cleanup**: Removed the unused `gutterContextMenuEvent` declaration and unregistration from `SignsFeature`.

---

## Verification
* Verified that compiler checks (`npm run tsc`) pass cleanly.
* Verified that formatting and linter checks (`npm run lint`) pass with no warnings.
