### PR TITLE
fix(gitManager): prevent naive path slicing and trailing slashes

### DIFF
--- a/src/gitManager/gitManager.ts
+++ b/src/gitManager/gitManager.ts
@@ -136,6 +136,9 @@ export abstract class GitManager {
     // Constructs a path relative to the vault from a path relative to the git repository
     getRelativeVaultPath(path: string): string {
         if (this.plugin.settings.basePath) {
+            if (path === "" || path === ".") {
+                return this.plugin.settings.basePath;
+            }
             return this.plugin.settings.basePath + "/" + path;
         } else {
             return path;
@@ -150,11 +153,13 @@ export abstract class GitManager {
         doConversion: boolean = true
     ): string {
         if (doConversion) {
-            if (this.plugin.settings.basePath.length > 0) {
-                //Expect the case that the git repository is located inside the vault on mobile platform currently.
-                return filePath.substring(
-                    this.plugin.settings.basePath.length + 1
-                );
+            const basePath = this.plugin.settings.basePath;
+            if (basePath && basePath.length > 0) {
+                if (filePath.startsWith(basePath + "/")) {
+                    return filePath.substring(basePath.length + 1);
+                } else if (filePath === basePath) {
+                    return "";
+                }
             }
         }
         return filePath;


### PR DESCRIPTION
# Description
This PR improves the safety of path conversion methods in `GitManager`. Specifically:
1. It prevents naive substring slicing in `getRelativeRepoPath` when a file path does not actually start with the git repository's `basePath` subfolder.
2. It handles empty or `.` path arguments cleanly in `getRelativeVaultPath` to avoid generating paths with trailing slashes.

---

## The Issue
When a Git repository is configured in a subfolder of the vault (via the `basePath` setting), `getRelativeRepoPath` previously chopped off a fixed number of characters corresponding to `basePath.length + 1` from the start of paths.

If a path did not reside under `basePath` (or mismatched), it got sliced blindly, leading to corrupted file paths being passed to Git commands.

Additionally, `getRelativeVaultPath("")` would return `basePath + "/"`, producing paths with unnecessary trailing slashes.

---

## The Fix
1. **Safety check in getRelativeRepoPath**: Verify that the file path actually starts with the subfolder path before executing the substring slicing:
   ```typescript
   const basePath = this.plugin.settings.basePath;
   if (basePath && basePath.length > 0) {
       if (filePath.startsWith(basePath + "/")) {
           return filePath.substring(basePath.length + 1);
       } else if (filePath === basePath) {
           return "";
       }
   }
   ```
2. **Trailing slash prevention in getRelativeVaultPath**:
   ```typescript
   if (path === "" || path === ".") {
       return this.plugin.settings.basePath;
   }
   ```

---

## Verification
* Verified that compiler checks (`npm run tsc`) pass cleanly.
* Verified that formatting and linter checks (`npm run lint`) pass with no warnings.
