### PR TITLE
fix(isomorphicGit): support root commits in diff generation

### DIFF
--- a/src/gitManager/isomorphicGit.ts
+++ b/src/gitManager/isomorphicGit.ts
@@ -1164,17 +1164,21 @@ export class IsomorphicGit extends GitManager {
                 oid: hash,
             });
 
-            const previousContent = await readBlob({
-                ...this.getRepo(),
-                filepath: filePath,
-                oid: commit.commit.parent.first()!,
-            })
-                .then((headBlob) => new TextDecoder().decode(headBlob.blob))
-                .catch((err) => {
-                    if (err instanceof git.Errors.NotFoundError)
-                        return undefined;
-                    throw err;
-                });
+            const parentOid = commit.commit.parent.first();
+            let previousContent: string | undefined;
+            if (parentOid) {
+                previousContent = await readBlob({
+                    ...this.getRepo(),
+                    filepath: filePath,
+                    oid: parentOid,
+                })
+                    .then((headBlob) => new TextDecoder().decode(headBlob.blob))
+                    .catch((err) => {
+                        if (err instanceof git.Errors.NotFoundError)
+                            return undefined;
+                        throw err;
+                    });
+            }
 
             const diff = createPatch(
                 vaultPath,


### PR DESCRIPTION
# Description
This PR safeguards parent commit retrieval inside `IsomorphicGit.getDiffString` to support repositories with initial or root commits.

---

## The Issue
When generating a file diff, `getDiffString` attempts to fetch the file contents at the parent commit using:
```typescript
commit.commit.parent.first()!
```
However, for the initial/root commit of a Git repository, `parent` is an empty array. Calling `parent.first()!` returns `undefined`, which is then passed to `readBlob()` as `oid`. This triggers a `TypeError` / `NotFoundError` inside `isomorphic-git`, causing the entire diff string retrieval to crash when viewing changes on the first commit of the repository.

---

## The Fix
Verify that `parentOid` is defined before calling `readBlob`. If it is undefined (i.e. the commit has no parent), we return `undefined` content, allowing `createPatch` to diff against an empty file cleanly.
```typescript
const parentOid = commit.commit.parent.first();
const previousContent = parentOid
    ? await readBlob({
          ...this.getRepo(),
          filepath: filePath,
          oid: parentOid,
      })
          .then((headBlob) =>
              new TextDecoder().decode(headBlob.blob)
          )
          .catch((err) => {
              if (err instanceof git.Errors.NotFoundError)
                  return undefined;
              throw err;
          })
    : undefined;
```

---

## Verification
* Verified that compiler checks (`npm run tsc`) pass cleanly.
* Verified that formatting and linter checks (`npm run lint`) pass with no warnings.
